### PR TITLE
Config updates

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -29,9 +29,10 @@ type Config struct {
 	ListenAddress string
 	ListenPort    int
 
-	Prefix string
+	Prefix  string
+	DataDir string
+	LogDir  string
 
-	LeaseTime       time.Duration
 	SyncInterval    time.Duration
 	RefreshInterval time.Duration
 
@@ -41,55 +42,87 @@ type Config struct {
 	TLSCA      string
 
 	Datastore   string
+	endpoints   string
 	Endpoints   []string
 	AuthEnabled bool
 	Username    string
 	Password    string
 }
 
-// New generates a new config object
-func New() *Config {
-	ifaceName := flag.String("interface-name", "quantum%d", "The name for the TUN interface that will be used for forwarding. Use %d to have the OS pick an available interface name.")
+func handleDefaultString(name, def string) string {
+	env := "QUANTUM_" + strings.ToUpper(strings.Replace(name, "-", "_", 10))
+	output := os.Getenv(env)
+	if output == "" {
+		return def
+	}
+	return output
+}
 
-	privateIP := flag.String("private-ip", "", "The private ip address of this node.")
-	publicIP := flag.String("public-ip", "", "The public ip address of this node.")
+func handleDefaultInt(name string, def int) int {
+	str := strconv.Itoa(def)
+	output, err := strconv.Atoi(handleDefaultString(name, str))
+	if err != nil {
+		panic(err)
+	}
+	return output
+}
 
-	laddr := flag.String("listen-address", "0.0.0.0", "The ip address to listen on for forwarded packets.")
-	lport := flag.Int("listen-port", 1099, "The ip port to listen on for forwarded packets.")
+func handleDefaultDuration(name string, def time.Duration) time.Duration {
+	str := def.String()
+	output, err := time.ParseDuration(handleDefaultString(name, str))
+	if err != nil {
+		panic(err)
+	}
+	return output
+}
 
-	prefix := flag.String("prefix", "quantum", "The etcd key that quantum information is stored under.")
-	dataDir := flag.String("data-dir", "/var/lib/quantum", "The data directory for quantum to use for persistent state.")
-	leaseTime := flag.Duration("lease-time", 300, "Lease time for the private ip address.")
-	syncInterval := flag.Duration("sync-interval", 30, "The backend sync interval")
-	refreshInterval := flag.Duration("refresh-interval", 60, "The backend lease refresh interval.")
+func (cfg *Config) handleCli() {
+	flag.StringVar(&cfg.InterfaceName, "interface-name", handleDefaultString("interface-name", "quantum%d"), "The name for the TUN interface that will be used for forwarding. Use %d to have the OS pick an available interface name.")
 
-	tlsCert := flag.String("tls-cert", "", "The client certificate to use for authentication with the backend datastore.")
-	tlsKey := flag.String("tls-key", "", "The client key to use for authentication with the backend datastore.")
-	tlsCA := flag.String("tls-ca-cert", "", "The CA certificate to authenticate the backend datastore.")
+	flag.StringVar(&cfg.PrivateIP, "private-ip", handleDefaultString("private-ip", ""), "The private ip address of this node.")
+	flag.StringVar(&cfg.PublicIP, "public-ip", handleDefaultString("public-ip", ""), "The public ip address of this node.")
 
-	datastore := flag.String("datastore", "etcd", "The datastore backend to use, either consul or etcd")
-	endpoints := flag.String("endpoints", "127.0.0.1:2379", "The datastore endpoints to use, in a comma separated list.")
-	username := flag.String("username", "", "The datastore username to use for authentication.")
-	password := flag.String("password", "", "The datastore password to use for authentication.")
+	flag.StringVar(&cfg.ListenAddress, "listen-address", handleDefaultString("listen-address", "0.0.0.0"), "The ip address to listen on for forwarded packets.")
+	flag.IntVar(&cfg.ListenPort, "listen-port", handleDefaultInt("listen-port", 1099), "The ip port to listen on for forwarded packets.")
+
+	flag.StringVar(&cfg.Prefix, "prefix", handleDefaultString("prefix", "quantum"), "The etcd key that quantum information is stored under.")
+	flag.StringVar(&cfg.DataDir, "data-dir", handleDefaultString("data-dir", "/var/lib/quantum"), "The data directory for quantum to use for persistent state.")
+	flag.StringVar(&cfg.LogDir, "log-dir", handleDefaultString("log-dir", ""), "The log directory to write logs to, if this is ommited logs are written to stdout/stderr.")
+
+	flag.DurationVar(&cfg.SyncInterval, "sync-interval", handleDefaultDuration("sync-interval", 30), "The backend sync interval")
+	flag.DurationVar(&cfg.RefreshInterval, "refresh-interval", handleDefaultDuration("refresh-interval", 60), "The backend lease refresh interval.")
+
+	flag.StringVar(&cfg.TLSCert, "tls-cert", handleDefaultString("tls-cert", ""), "The client certificate to use for authentication with the backend datastore.")
+	flag.StringVar(&cfg.TLSKey, "tls-key", handleDefaultString("tls-key", ""), "The client key to use for authentication with the backend datastore.")
+	flag.StringVar(&cfg.TLSCA, "tls-ca-cert", handleDefaultString("tls-ca-cert", ""), "The CA certificate to authenticate the backend datastore.")
+
+	flag.StringVar(&cfg.Datastore, "datastore", handleDefaultString("datastore", "etcd"), "The datastore backend to use, either consul or etcd")
+
+	flag.StringVar(&cfg.endpoints, "endpoints", handleDefaultString("endpoints", "127.0.0.1:2379"), "A comma delimited list of datastore endpoints to use.")
+	flag.StringVar(&cfg.Username, "username", handleDefaultString("username", ""), "The datastore username to use for authentication.")
+	flag.StringVar(&cfg.Password, "password", handleDefaultString("password", ""), "The datastore password to use for authentication.")
 
 	flag.Parse()
+}
 
-	parsedEndpoints := strings.Split(*endpoints, ",")
+func (cfg *Config) handleComputed() {
+	cfg.Endpoints = strings.Split(cfg.endpoints, ",")
+
 	pubkey, privkey := ecdh.GenerateECKeyPair()
+	cfg.PublicKey = pubkey
+	cfg.PrivateKey = privkey
 
-	tlsEnabled := false
-	if (*tlsCert != "" && *tlsKey != "") || *tlsCA != "" {
-		tlsEnabled = true
+	if (cfg.TLSCert != "" && cfg.TLSKey != "") || cfg.TLSCA != "" {
+		cfg.TLSEnabled = true
 	}
 
-	authEnabled := false
-	if *username != "" {
-		authEnabled = true
+	if cfg.Username != "" {
+		cfg.AuthEnabled = true
 	}
 
-	os.MkdirAll(*dataDir, os.ModeDir)
+	os.MkdirAll(cfg.DataDir, os.ModeDir)
 	machineID := make([]byte, 32)
-	machineIDPath := path.Join(*dataDir, "machine-id")
+	machineIDPath := path.Join(cfg.DataDir, "machine-id")
 	if _, err := os.Stat(machineIDPath); os.IsNotExist(err) {
 		rand.Read(machineID)
 		ioutil.WriteFile(machineIDPath, machineID, os.ModePerm)
@@ -97,29 +130,15 @@ func New() *Config {
 		buf, _ := ioutil.ReadFile(machineIDPath)
 		machineID = buf
 	}
+	cfg.MachineID = hex.EncodeToString(machineID)
 
-	return &Config{
-		InterfaceName:   *ifaceName,
-		MachineID:       hex.EncodeToString(machineID),
-		PrivateIP:       *privateIP,
-		PublicIP:        *publicIP,
-		PublicAddress:   *publicIP + ":" + strconv.Itoa(*lport),
-		PrivateKey:      privkey,
-		PublicKey:       pubkey,
-		ListenAddress:   *laddr,
-		ListenPort:      *lport,
-		Prefix:          *prefix,
-		LeaseTime:       *leaseTime,
-		SyncInterval:    *syncInterval,
-		RefreshInterval: *refreshInterval,
-		TLSCert:         *tlsCert,
-		TLSKey:          *tlsKey,
-		TLSCA:           *tlsCA,
-		TLSEnabled:      tlsEnabled,
-		Datastore:       *datastore,
-		Endpoints:       parsedEndpoints,
-		AuthEnabled:     authEnabled,
-		Username:        *username,
-		Password:        *password,
-	}
+	cfg.PublicAddress = cfg.PublicIP + ":" + strconv.Itoa(cfg.ListenPort)
+}
+
+// New generates a new config object
+func New() *Config {
+	cfg := &Config{}
+	cfg.handleCli()
+	cfg.handleComputed()
+	return cfg
 }

--- a/config/config.go
+++ b/config/config.go
@@ -3,8 +3,12 @@ package config
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
+	"errors"
 	"flag"
 	"github.com/Supernomad/quantum/ecdh"
+	"github.com/go-playground/log"
+	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
 	"path"
@@ -29,9 +33,10 @@ type Config struct {
 	ListenAddress string
 	ListenPort    int
 
-	Prefix  string
-	DataDir string
-	LogDir  string
+	Prefix   string
+	ConfFile string
+	DataDir  string
+	LogDir   string
 
 	SyncInterval    time.Duration
 	RefreshInterval time.Duration
@@ -47,62 +52,77 @@ type Config struct {
 	AuthEnabled bool
 	Username    string
 	Password    string
+
+	fileData map[string]string
 }
 
-func handleDefaultString(name, def string) string {
+func (cfg *Config) handleDefaultString(name, def string) string {
 	env := "QUANTUM_" + strings.ToUpper(strings.Replace(name, "-", "_", 10))
 	output := os.Getenv(env)
 	if output == "" {
+		if output, ok := cfg.fileData[name]; ok {
+			return output
+		}
 		return def
 	}
 	return output
 }
 
-func handleDefaultInt(name string, def int) int {
+func (cfg *Config) handleDefaultInt(name string, def int) int {
 	str := strconv.Itoa(def)
-	output, err := strconv.Atoi(handleDefaultString(name, str))
+	output, err := strconv.Atoi(cfg.handleDefaultString(name, str))
 	if err != nil {
 		panic(err)
 	}
 	return output
 }
 
-func handleDefaultDuration(name string, def time.Duration) time.Duration {
+func (cfg *Config) handleDefaultDuration(name string, def time.Duration) time.Duration {
 	str := def.String()
-	output, err := time.ParseDuration(handleDefaultString(name, str))
+	output, err := time.ParseDuration(cfg.handleDefaultString(name, str))
 	if err != nil {
 		panic(err)
 	}
 	return output
 }
 
-func (cfg *Config) handleCli() {
-	flag.StringVar(&cfg.InterfaceName, "interface-name", handleDefaultString("interface-name", "quantum%d"), "The name for the TUN interface that will be used for forwarding. Use %d to have the OS pick an available interface name.")
+func (cfg *Config) handleCli() error {
+	flag.StringVar(&cfg.ConfFile, "conf-file", cfg.handleDefaultString("conf-file", ""), "The json or yaml file to load configuration data from.")
+	flag.Parse()
 
-	flag.StringVar(&cfg.PrivateIP, "private-ip", handleDefaultString("private-ip", ""), "The private ip address of this node.")
-	flag.StringVar(&cfg.PublicIP, "public-ip", handleDefaultString("public-ip", ""), "The public ip address of this node.")
+	err := cfg.handleFile()
+	if err != nil {
+		return err
+	}
 
-	flag.StringVar(&cfg.ListenAddress, "listen-address", handleDefaultString("listen-address", "0.0.0.0"), "The ip address to listen on for forwarded packets.")
-	flag.IntVar(&cfg.ListenPort, "listen-port", handleDefaultInt("listen-port", 1099), "The ip port to listen on for forwarded packets.")
+	flag.StringVar(&cfg.InterfaceName, "interface-name", cfg.handleDefaultString("interface-name", "quantum%d"), "The name for the TUN interface that will be used for forwarding. Use %d to have the OS pick an available interface name.")
 
-	flag.StringVar(&cfg.Prefix, "prefix", handleDefaultString("prefix", "quantum"), "The etcd key that quantum information is stored under.")
-	flag.StringVar(&cfg.DataDir, "data-dir", handleDefaultString("data-dir", "/var/lib/quantum"), "The data directory for quantum to use for persistent state.")
-	flag.StringVar(&cfg.LogDir, "log-dir", handleDefaultString("log-dir", ""), "The log directory to write logs to, if this is ommited logs are written to stdout/stderr.")
+	flag.StringVar(&cfg.PrivateIP, "private-ip", cfg.handleDefaultString("private-ip", ""), "The private ip address of this node.")
+	flag.StringVar(&cfg.PublicIP, "public-ip", cfg.handleDefaultString("public-ip", ""), "The public ip address of this node.")
 
-	flag.DurationVar(&cfg.SyncInterval, "sync-interval", handleDefaultDuration("sync-interval", 30), "The backend sync interval")
-	flag.DurationVar(&cfg.RefreshInterval, "refresh-interval", handleDefaultDuration("refresh-interval", 60), "The backend lease refresh interval.")
+	flag.StringVar(&cfg.ListenAddress, "listen-address", cfg.handleDefaultString("listen-address", "0.0.0.0"), "The ip address to listen on for forwarded packets.")
+	flag.IntVar(&cfg.ListenPort, "listen-port", cfg.handleDefaultInt("listen-port", 1099), "The ip port to listen on for forwarded packets.")
 
-	flag.StringVar(&cfg.TLSCert, "tls-cert", handleDefaultString("tls-cert", ""), "The client certificate to use for authentication with the backend datastore.")
-	flag.StringVar(&cfg.TLSKey, "tls-key", handleDefaultString("tls-key", ""), "The client key to use for authentication with the backend datastore.")
-	flag.StringVar(&cfg.TLSCA, "tls-ca-cert", handleDefaultString("tls-ca-cert", ""), "The CA certificate to authenticate the backend datastore.")
+	flag.StringVar(&cfg.Prefix, "prefix", cfg.handleDefaultString("prefix", "quantum"), "The etcd key that quantum information is stored under.")
 
-	flag.StringVar(&cfg.Datastore, "datastore", handleDefaultString("datastore", "etcd"), "The datastore backend to use, either consul or etcd")
+	flag.StringVar(&cfg.DataDir, "data-dir", cfg.handleDefaultString("data-dir", "/var/lib/quantum"), "The data directory for quantum to use for persistent state.")
+	flag.StringVar(&cfg.LogDir, "log-dir", cfg.handleDefaultString("log-dir", ""), "The log directory to write logs to, if this is ommited logs are written to stdout/stderr.")
 
-	flag.StringVar(&cfg.endpoints, "endpoints", handleDefaultString("endpoints", "127.0.0.1:2379"), "A comma delimited list of datastore endpoints to use.")
-	flag.StringVar(&cfg.Username, "username", handleDefaultString("username", ""), "The datastore username to use for authentication.")
-	flag.StringVar(&cfg.Password, "password", handleDefaultString("password", ""), "The datastore password to use for authentication.")
+	flag.DurationVar(&cfg.SyncInterval, "sync-interval", cfg.handleDefaultDuration("sync-interval", 30), "The backend sync interval")
+	flag.DurationVar(&cfg.RefreshInterval, "refresh-interval", cfg.handleDefaultDuration("refresh-interval", 60), "The backend lease refresh interval.")
+
+	flag.StringVar(&cfg.TLSCert, "tls-cert", cfg.handleDefaultString("tls-cert", ""), "The client certificate to use for authentication with the backend datastore.")
+	flag.StringVar(&cfg.TLSKey, "tls-key", cfg.handleDefaultString("tls-key", ""), "The client key to use for authentication with the backend datastore.")
+	flag.StringVar(&cfg.TLSCA, "tls-ca-cert", cfg.handleDefaultString("tls-ca-cert", ""), "The CA certificate to authenticate the backend datastore.")
+
+	flag.StringVar(&cfg.Datastore, "datastore", cfg.handleDefaultString("datastore", "etcd"), "The datastore backend to use, either consul or etcd")
+
+	flag.StringVar(&cfg.endpoints, "endpoints", cfg.handleDefaultString("endpoints", "127.0.0.1:2379"), "A comma delimited list of datastore endpoints to use.")
+	flag.StringVar(&cfg.Username, "username", cfg.handleDefaultString("username", ""), "The datastore username to use for authentication.")
+	flag.StringVar(&cfg.Password, "password", cfg.handleDefaultString("password", ""), "The datastore password to use for authentication.")
 
 	flag.Parse()
+	return nil
 }
 
 func (cfg *Config) handleComputed() {
@@ -135,10 +155,42 @@ func (cfg *Config) handleComputed() {
 	cfg.PublicAddress = cfg.PublicIP + ":" + strconv.Itoa(cfg.ListenPort)
 }
 
+func (cfg *Config) handleFile() error {
+	if cfg.ConfFile != "" {
+		buf, err := ioutil.ReadFile(cfg.ConfFile)
+		if err != nil {
+			return err
+		}
+
+		data := make(map[string]string)
+		ext := path.Ext(cfg.ConfFile)
+		switch ext {
+		case ".json":
+			err = json.Unmarshal(buf, &data)
+		case ".yaml":
+			err = yaml.Unmarshal(buf, &data)
+		case ".yml":
+			err = yaml.Unmarshal(buf, &data)
+		default:
+			return errors.New("The configuration file is not in a supported format.")
+		}
+
+		cfg.fileData = data
+	} else {
+		cfg.fileData = make(map[string]string)
+	}
+
+	return nil
+}
+
 // New generates a new config object
-func New() *Config {
+func New() (*Config, error) {
 	cfg := &Config{}
-	cfg.handleCli()
+	err := cfg.handleCli()
+	if err != nil {
+		log.Error("Error handling config:", err)
+		return nil, err
+	}
 	cfg.handleComputed()
-	return cfg
+	return cfg, nil
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,10 +32,16 @@ services:
       - $GOPATH/bin/quantum:/bin/quantum
       - ./certs/:/etc/quantum/certs/:ro
       - quantum1:/var/lib/quantum
+    environment:
+      QUANTUM_ENDPOINTS: "etcd.quantum.dev:2379"
+      QUANTUM_PUBLIC_IP: "172.18.0.3"
+      QUANTUM_TLS_CA_CERT: "/etc/quantum/certs/ca.crt"
+      QUANTUM_TLS_CERT: "/etc/quantum/certs/quantum1.quantum.dev.crt"
+      QUANTUM_TLS_KEY: "/etc/quantum/certs/quantum1.quantum.dev.key"
     networks:
       perf_net:
         ipv4_address: 172.18.0.3
-    entrypoint: ["/bin/quantum", "-endpoints", "etcd.quantum.dev:2379", "-public-ip", "172.18.0.3", "--tls-cert", "/etc/quantum/certs/quantum1.quantum.dev.crt", "--tls-key", "/etc/quantum/certs/quantum1.quantum.dev.key", "--tls-ca-cert", "/etc/quantum/certs/ca.crt"]
+    entrypoint: ["/bin/quantum"]
   etcd:
     container_name: etcd
     image: quay.io/coreos/etcd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - /dev/net/tun:/dev/net/tun
       - $GOPATH/bin/quantum:/bin/quantum
       - ./certs/:/etc/quantum/certs/:ro
-      - quantum0:/var/lib/quantum
+      - quantum0:/var/lib/quantum/
     networks:
       perf_net:
         ipv4_address: 172.18.0.2
@@ -31,7 +31,7 @@ services:
       - /dev/net/tun:/dev/net/tun
       - $GOPATH/bin/quantum:/bin/quantum
       - ./certs/:/etc/quantum/certs/:ro
-      - quantum1:/var/lib/quantum
+      - quantum1:/var/lib/quantum/
     environment:
       QUANTUM_ENDPOINTS: "etcd.quantum.dev:2379"
       QUANTUM_PUBLIC_IP: "172.18.0.3"
@@ -41,6 +41,27 @@ services:
     networks:
       perf_net:
         ipv4_address: 172.18.0.3
+    entrypoint: ["/bin/quantum"]
+  quantum2:
+    container_name: quantum2
+    build:
+      context: "."
+    extra_hosts:
+      - "etcd.quantum.dev:172.18.0.4"
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    volumes:
+      - /dev/net/tun:/dev/net/tun
+      - $GOPATH/bin/quantum:/bin/quantum
+      - ./bin/quantum.yml:/etc/quantum/quantum.yml:ro
+      - ./certs/:/etc/quantum/certs/:ro
+      - quantum2:/var/lib/quantum/
+    environment:
+      QUANTUM_CONF_FILE: "/etc/quantum/quantum.yml"
+    networks:
+      perf_net:
+        ipv4_address: 172.18.0.5
     entrypoint: ["/bin/quantum"]
   etcd:
     container_name: etcd
@@ -76,4 +97,6 @@ volumes:
   quantum0:
     driver: local
   quantum1:
+    driver: local
+  quantum2:
     driver: local

--- a/main.go
+++ b/main.go
@@ -29,7 +29,8 @@ func main() {
 	cores := runtime.NumCPU()
 	runtime.GOMAXPROCS(cores * 2)
 
-	cfg := config.New()
+	cfg, err := config.New()
+	handleError(err)
 
 	store, err := backend.New(cfg)
 	handleError(err)


### PR DESCRIPTION
This gets #12 fully implemented.

The configuration can now be supplied via cli arguments, environment variables, and a json or yml config file.  The configuration mappings are 1 to 1 across all methods, and all methods are always checked on start up.

The precedence of which is simply: 
- cli arguments override both environment variables and config file entries
- environment variables override config file entries but are superseded by cli arguments
- config file entries are superseded by both environment variables and cli arguments
