### PR TITLE
Static and DHCP IP assignment collisions

### DIFF
--- a/common/networkConfig.go
+++ b/common/networkConfig.go
@@ -11,11 +11,13 @@ var DefaultNetworkConfig *NetworkConfig
 
 // NetworkConfig object to represent the current network.
 type NetworkConfig struct {
-	Network   string
-	LeaseTime time.Duration
+	Network        string
+	ReservedSubnet string
+	LeaseTime      time.Duration
 
-	BaseIP net.IP     `json:"-"`
-	IPNet  *net.IPNet `json:"-"`
+	BaseIP        net.IP     `json:"-"`
+	IPNet         *net.IPNet `json:"-"`
+	ReservedIPNet *net.IPNet `json:"-"`
 }
 
 // ParseNetworkConfig from the return of the backend datastore
@@ -30,6 +32,14 @@ func ParseNetworkConfig(data []byte) (*NetworkConfig, error) {
 
 	networkCfg.BaseIP = baseIP
 	networkCfg.IPNet = ipnet
+
+	_, resIPNet, err := net.ParseCIDR(networkCfg.ReservedSubnet)
+	if err != nil {
+		return nil, err
+	}
+
+	networkCfg.ReservedIPNet = resIPNet
+
 	return &networkCfg, nil
 }
 
@@ -42,10 +52,15 @@ func (networkCfg *NetworkConfig) Bytes() []byte {
 func init() {
 	defaultLeaseTime, _ := time.ParseDuration("48h")
 	DefaultNetworkConfig = &NetworkConfig{
-		Network:   "10.9.0.0/16",
-		LeaseTime: defaultLeaseTime,
+		Network:        "10.9.0.0/16",
+		ReservedSubnet: "10.9.0.0/20",
+		LeaseTime:      defaultLeaseTime,
 	}
+
 	baseIP, ipnet, _ := net.ParseCIDR(DefaultNetworkConfig.Network)
 	DefaultNetworkConfig.BaseIP = baseIP
 	DefaultNetworkConfig.IPNet = ipnet
+
+	_, resIPNet, _ := net.ParseCIDR(DefaultNetworkConfig.ReservedSubnet)
+	DefaultNetworkConfig.ReservedIPNet = resIPNet
 }


### PR DESCRIPTION
Fixed static ip collisions with dhcp assignments by adding a reserved subnet to the network config, of which the default is the 10.9.0.0/20 network.

So dhcp will now skip over any address within the reserved subnet, allowing safe static ip assignments. However this does not protect against user error of assigning the same ip to multiple nodes via static assignment.

This resolves #53 and resolves #49 