### PR TITLE
Public IP auto configuration

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -18,7 +18,7 @@ import (
 	"time"
 )
 
-var google net.IP = net.ParseIP("8.8.8.8")
+var google = net.ParseIP("8.8.8.8")
 
 // Config handles marshalling user supplied configuration data
 type Config struct {

--- a/common/config.go
+++ b/common/config.go
@@ -6,8 +6,10 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
+	"github.com/vishvananda/netlink"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
+	"net"
 	"os"
 	"path"
 	"runtime"
@@ -15,6 +17,8 @@ import (
 	"strings"
 	"time"
 )
+
+var google net.IP = net.ParseIP("8.8.8.8")
 
 // Config handles marshalling user supplied configuration data
 type Config struct {
@@ -128,7 +132,7 @@ func (cfg *Config) handleCli() {
 	flag.Parse()
 }
 
-func (cfg *Config) handleComputed() {
+func (cfg *Config) handleComputed() error {
 	cfg.Endpoints = strings.Split(cfg.endpoints, ",")
 
 	pubkey, privkey := GenerateECKeyPair()
@@ -155,12 +159,23 @@ func (cfg *Config) handleComputed() {
 	}
 	cfg.MachineID = hex.EncodeToString(machineID)
 
+	if cfg.PublicIP == "" {
+		routes, err := netlink.RouteGet(google)
+		if err != nil {
+			return err
+		}
+
+		cfg.PublicIP = routes[0].Src.String()
+	}
+
 	cfg.PublicAddress = cfg.PublicIP + ":" + strconv.Itoa(cfg.ListenPort)
 
 	cores := runtime.NumCPU()
 	runtime.GOMAXPROCS(cores * 2)
 
 	cfg.NumWorkers = cores
+
+	return nil
 }
 
 func (cfg *Config) parseFileData(data map[string]string) error {
@@ -260,10 +275,16 @@ func (cfg *Config) handleFile() error {
 func NewConfig() (*Config, error) {
 	cfg := &Config{notSet: make(map[string]bool)}
 	cfg.handleCli()
+
 	err := cfg.handleFile()
 	if err != nil {
 		return nil, err
 	}
-	cfg.handleComputed()
+
+	err = cfg.handleComputed()
+	if err != nil {
+		return nil, err
+	}
+
 	return cfg, nil
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     networks:
       perf_net:
         ipv4_address: 172.18.0.2
-    entrypoint: ["/bin/start_quantum.sh", "-endpoints", "etcd.quantum.dev:2379", "-private-ip", "10.9.0.1", "-public-ip", "172.18.0.2", "--tls-cert", "/etc/quantum/certs/quantum0.quantum.dev.crt", "--tls-key", "/etc/quantum/certs/quantum0.quantum.dev.key", "--tls-ca-cert", "/etc/quantum/certs/ca.crt"]
+    entrypoint: ["/bin/start_quantum.sh", "-endpoints", "etcd.quantum.dev:2379", "-private-ip", "10.9.0.1", "--tls-cert", "/etc/quantum/certs/quantum0.quantum.dev.crt", "--tls-key", "/etc/quantum/certs/quantum0.quantum.dev.key", "--tls-ca-cert", "/etc/quantum/certs/ca.crt"]
   quantum1:
     container_name: quantum1
     build:


### PR DESCRIPTION
Added auto configuration of the public ip based on the routes designated to reach google. While this won't always work its a good compromise to get the feature in.

Basically `quantum` will now find the ip address responsible for handling internet bound network traffic. This will work on anything without a NAT or running ipv6 public addresses, if the server is running behind a NAT and is running ipv4 then the public ip will still have to be manually entered.

This resolves #50 