### PR TITLE
Rolling restart

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -3,6 +3,7 @@ package common
 import (
 	"encoding/binary"
 	"net"
+	"strconv"
 )
 
 const (
@@ -50,4 +51,26 @@ func IncrementIP(ip net.IP) {
 			break
 		}
 	}
+}
+
+// ToStringArray taks in a slice of ints and returns a slice of strings
+func ToStringArray(ints []int) []string {
+	strs := make([]string, len(ints))
+	for i := 0; i < len(ints); i++ {
+		strs[i] = strconv.Itoa(ints[i])
+	}
+	return strs
+}
+
+// ToIntArray takes in a slice of strings and returns a slice of ints or an error
+func ToIntArray(strs []string) ([]int, error) {
+	ints := make([]int, len(strs))
+	for i := 0; i < len(strs); i++ {
+		j, err := strconv.Atoi(strs[i])
+		if err != nil {
+			return nil, err
+		}
+		ints[i] = j
+	}
+	return ints, nil
 }

--- a/common/common.go
+++ b/common/common.go
@@ -3,7 +3,13 @@ package common
 import (
 	"encoding/binary"
 	"net"
-	"strconv"
+)
+
+const (
+	// ReloadTrigger is the argument to trigger reusing passed in file descriptors
+	ReloadTrigger = ":|reload|:"
+	// RealInterfaceNameEnv is the environment variable the the real interface name is stored for reloads.
+	RealInterfaceNameEnv = "QUANTUM_REAL_INTERFACE_NAME"
 )
 
 const (
@@ -53,24 +59,12 @@ func IncrementIP(ip net.IP) {
 	}
 }
 
-// ToStringArray taks in a slice of ints and returns a slice of strings
-func ToStringArray(ints []int) []string {
-	strs := make([]string, len(ints))
-	for i := 0; i < len(ints); i++ {
-		strs[i] = strconv.Itoa(ints[i])
-	}
-	return strs
-}
-
-// ToIntArray takes in a slice of strings and returns a slice of ints or an error
-func ToIntArray(strs []string) ([]int, error) {
-	ints := make([]int, len(strs))
-	for i := 0; i < len(strs); i++ {
-		j, err := strconv.Atoi(strs[i])
-		if err != nil {
-			return nil, err
+// StringInSlice returns true if the given string is in the given slice.
+func StringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
 		}
-		ints[i] = j
 	}
-	return ints, nil
+	return false
 }

--- a/common/common.go
+++ b/common/common.go
@@ -6,10 +6,8 @@ import (
 )
 
 const (
-	// ReloadTrigger is the argument to trigger reusing passed in file descriptors
-	ReloadTrigger = ":|reload|:"
 	// RealInterfaceNameEnv is the environment variable the the real interface name is stored for reloads.
-	RealInterfaceNameEnv = "QUANTUM_REAL_INTERFACE_NAME"
+	RealInterfaceNameEnv = "_QUANTUM_REAL_INTERFACE_NAME"
 )
 
 const (
@@ -57,14 +55,4 @@ func IncrementIP(ip net.IP) {
 			break
 		}
 	}
-}
-
-// StringInSlice returns true if the given string is in the given slice.
-func StringInSlice(a string, list []string) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-	return false
 }

--- a/common/config.go
+++ b/common/config.go
@@ -43,7 +43,7 @@ type Config struct {
 	Prefix   string
 	ConfFile string
 	DataDir  string
-	LogDir   string
+	PidFile  string
 
 	SyncInterval    time.Duration
 	RefreshInterval time.Duration
@@ -116,7 +116,7 @@ func (cfg *Config) handleCli() {
 
 	flag.StringVar(&cfg.Prefix, "prefix", cfg.handleDefaultString("prefix", "quantum"), "The etcd key that quantum information is stored under.")
 	flag.StringVar(&cfg.DataDir, "data-dir", cfg.handleDefaultString("data-dir", "/var/lib/quantum"), "The data directory for quantum to use for persistent state.")
-	flag.StringVar(&cfg.LogDir, "log-dir", cfg.handleDefaultString("log-dir", ""), "The log directory to write logs to, if this is ommited logs are written to stdout/stderr.")
+	flag.StringVar(&cfg.PidFile, "pid-file", cfg.handleDefaultString("pid-file", "/var/run/quantum.pid"), "The pid file to write the process id to for supervison.")
 
 	flag.DurationVar(&cfg.SyncInterval, "sync-interval", cfg.handleDefaultDuration("sync-interval", 30), "The backend sync interval")
 	flag.DurationVar(&cfg.RefreshInterval, "refresh-interval", cfg.handleDefaultDuration("refresh-interval", 60), "The backend lease refresh interval.")
@@ -182,6 +182,9 @@ func (cfg *Config) handleComputed() error {
 		cfg.ReuseFDS = true
 	}
 
+	pid := os.Getpid()
+	ioutil.WriteFile(cfg.PidFile, []byte(strconv.Itoa(pid)), os.ModePerm)
+
 	return nil
 }
 
@@ -209,8 +212,8 @@ func (cfg *Config) parseFileData(data map[string]string) error {
 				cfg.Prefix = v
 			case "data-dir":
 				cfg.DataDir = v
-			case "log-dir":
-				cfg.LogDir = v
+			case "pid-file":
+				cfg.PidFile = v
 			case "stats-window":
 				dur, err := time.ParseDuration(v)
 				if err != nil {

--- a/common/config.go
+++ b/common/config.go
@@ -61,6 +61,9 @@ type Config struct {
 
 	NetworkConfig *NetworkConfig
 	notSet        map[string]bool
+
+	TunnelFDS []int
+	SocketFDS []int
 }
 
 func (cfg *Config) handleDefaultString(name, def string) string {
@@ -174,6 +177,24 @@ func (cfg *Config) handleComputed() error {
 	runtime.GOMAXPROCS(cores * 2)
 
 	cfg.NumWorkers = cores
+
+	strSockFDS := os.Getenv("QUANTUM_SOCK_FDS")
+	if strSockFDS != "" {
+		arr, err := ToIntArray(strings.Split(strSockFDS, ","))
+		if err != nil {
+			return err
+		}
+		cfg.SocketFDS = arr
+	}
+
+	strTunnelFDS := os.Getenv("QUANTUM_TUN_FDS")
+	if strTunnelFDS != "" {
+		arr, err := ToIntArray(strings.Split(strTunnelFDS, ","))
+		if err != nil {
+			return err
+		}
+		cfg.TunnelFDS = arr
+	}
 
 	return nil
 }

--- a/common/config.go
+++ b/common/config.go
@@ -22,10 +22,12 @@ var google = net.ParseIP("8.8.8.8")
 
 // Config handles marshalling user supplied configuration data
 type Config struct {
-	InterfaceName string
-	MachineID     string
-	NumWorkers    int
-	StatsWindow   time.Duration
+	RealInterfaceName string
+	InterfaceName     string
+	MachineID         string
+	NumWorkers        int
+	ReuseFDS          bool
+	StatsWindow       time.Duration
 
 	PrivateIP string
 	PublicIP  string
@@ -61,9 +63,6 @@ type Config struct {
 
 	NetworkConfig *NetworkConfig
 	notSet        map[string]bool
-
-	TunnelFDS []int
-	SocketFDS []int
 }
 
 func (cfg *Config) handleDefaultString(name, def string) string {
@@ -178,22 +177,9 @@ func (cfg *Config) handleComputed() error {
 
 	cfg.NumWorkers = cores
 
-	strSockFDS := os.Getenv("QUANTUM_SOCK_FDS")
-	if strSockFDS != "" {
-		arr, err := ToIntArray(strings.Split(strSockFDS, ","))
-		if err != nil {
-			return err
-		}
-		cfg.SocketFDS = arr
-	}
-
-	strTunnelFDS := os.Getenv("QUANTUM_TUN_FDS")
-	if strTunnelFDS != "" {
-		arr, err := ToIntArray(strings.Split(strTunnelFDS, ","))
-		if err != nil {
-			return err
-		}
-		cfg.TunnelFDS = arr
+	if StringInSlice(ReloadTrigger, os.Args) {
+		cfg.ReuseFDS = true
+		cfg.RealInterfaceName = os.Getenv("QUANTUM_REAL_INTERFACE_NAME")
 	}
 
 	return nil

--- a/common/config.go
+++ b/common/config.go
@@ -177,9 +177,9 @@ func (cfg *Config) handleComputed() error {
 
 	cfg.NumWorkers = cores
 
-	if StringInSlice(ReloadTrigger, os.Args) {
+	cfg.RealInterfaceName = os.Getenv(RealInterfaceNameEnv)
+	if cfg.RealInterfaceName != "" {
 		cfg.ReuseFDS = true
-		cfg.RealInterfaceName = os.Getenv("QUANTUM_REAL_INTERFACE_NAME")
 	}
 
 	return nil

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     container_name: quantum0
     build:
       context: "."
+    restart: unless-stopped
     extra_hosts:
       - "etcd.quantum.dev:172.18.0.4"
     cap_add:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
     container_name: quantum0
     build:
       context: "."
-    restart: unless-stopped
     extra_hosts:
       - "etcd.quantum.dev:172.18.0.4"
     cap_add:
@@ -71,6 +70,8 @@ services:
     volumes:
       - etcd:/var/lib/etcd
       - $GOPATH/src/github.com/Supernomad/quantum/bin/certs/:/etc/quantum/certs/:ro
+    ports:
+      - 2379:2379
     networks:
       perf_net:
         ipv4_address: 172.18.0.4

--- a/inet/inet.go
+++ b/inet/inet.go
@@ -33,6 +33,7 @@ type Interface interface {
 	Write(payload *common.Payload, queue int) bool
 	Open() error
 	Close() error
+	GetFDs() []int
 }
 
 // New Interface object

--- a/inet/mock.go
+++ b/inet/mock.go
@@ -33,6 +33,11 @@ func (mock *Mock) Close() error {
 	return nil
 }
 
+// GetFDs will return
+func (mock *Mock) GetFDs() []int {
+	return nil
+}
+
 func newMock(cfg *common.Config) *Mock {
 	return &Mock{}
 }

--- a/inet/mock.go
+++ b/inet/mock.go
@@ -33,7 +33,7 @@ func (mock *Mock) Close() error {
 	return nil
 }
 
-// GetFDs will return
+// GetFDs will return the underlying queue fds
 func (mock *Mock) GetFDs() []int {
 	return nil
 }

--- a/inet/tun.go
+++ b/inet/tun.go
@@ -54,7 +54,7 @@ func (tun *Tun) Close() error {
 	return nil
 }
 
-// GetFDs will return
+// GetFDs will return the underlying queue fds
 func (tun *Tun) GetFDs() []int {
 	return tun.queues
 }

--- a/inet/tun.go
+++ b/inet/tun.go
@@ -52,6 +52,11 @@ func (tun *Tun) Close() error {
 	return nil
 }
 
+// GetFDs will return
+func (tun *Tun) GetFDs() []int {
+	return tun.queues
+}
+
 // Read a packet off the tun
 func (tun *Tun) Read(buf []byte, queue int) (*common.Payload, bool) {
 	n, err := syscall.Read(tun.queues[queue], buf[common.PacketStart:])

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Supernomad/quantum/inet"
 	"github.com/Supernomad/quantum/socket"
 	"github.com/Supernomad/quantum/workers"
+	"io/ioutil"
 	"os"
 	"os/signal"
 	"strconv"
@@ -97,9 +98,9 @@ func main() {
 			outgoing.Stop()
 			store.Stop()
 
-			_, err := syscall.ForkExec(os.Args[0], os.Args, attr)
+			pid, err := syscall.ForkExec(os.Args[0], os.Args, attr)
 			handleError(log, err)
-
+			ioutil.WriteFile(cfg.PidFile, []byte(strconv.Itoa(pid)), os.ModePerm)
 			done <- struct{}{}
 		case sig == syscall.SIGINT || sig == syscall.SIGTERM || sig == syscall.SIGKILL:
 			log.Info.Println("[MAIN]", "Recieved termination signal from user. Terminating process.")

--- a/socket/mock.go
+++ b/socket/mock.go
@@ -33,6 +33,11 @@ func (mock *Mock) Close() error {
 	return nil
 }
 
+// GetFDs will return
+func (mock *Mock) GetFDs() []int {
+	return nil
+}
+
 func newMock(cfg *common.Config) *Mock {
 	return &Mock{}
 }

--- a/socket/mock.go
+++ b/socket/mock.go
@@ -33,7 +33,7 @@ func (mock *Mock) Close() error {
 	return nil
 }
 
-// GetFDs will return
+// GetFDs will return the underlying queue fds
 func (mock *Mock) GetFDs() []int {
 	return nil
 }

--- a/socket/socket.go
+++ b/socket/socket.go
@@ -20,6 +20,7 @@ type Socket interface {
 	Write(payload *common.Payload, mapping *common.Mapping, queue int) bool
 	Open() error
 	Close() error
+	GetFDs() []int
 }
 
 // New Socket object

--- a/socket/udp.go
+++ b/socket/udp.go
@@ -21,16 +21,21 @@ func (sock *UDP) Name() string {
 // Open the socket
 func (sock *UDP) Open() error {
 	for i := 0; i < sock.cfg.NumWorkers; i++ {
-		queue, err := createUDP()
-		if err != nil {
-			return err
-		}
+		var queue int
+		var err error
 
-		err = initUDP(queue, sock.sa)
-		if err != nil {
-			return err
+		if !sock.cfg.ReuseFDS {
+			queue, err = createUDP()
+			if err != nil {
+				return err
+			}
+			err = initUDP(queue, sock.sa)
+			if err != nil {
+				return err
+			}
+		} else {
+			queue = 3 + sock.cfg.NumWorkers + i
 		}
-
 		sock.queues[i] = queue
 	}
 	return nil

--- a/socket/udp.go
+++ b/socket/udp.go
@@ -51,7 +51,7 @@ func (sock *UDP) Close() error {
 	return nil
 }
 
-// GetFDs will return
+// GetFDs will return the underlying queue fds
 func (sock *UDP) GetFDs() []int {
 	return sock.queues
 }

--- a/socket/udp.go
+++ b/socket/udp.go
@@ -46,6 +46,11 @@ func (sock *UDP) Close() error {
 	return nil
 }
 
+// GetFDs will return
+func (sock *UDP) GetFDs() []int {
+	return sock.queues
+}
+
 // Read a packet from the socket
 func (sock *UDP) Read(buf []byte, queue int) (*common.Payload, bool) {
 	n, _, err := syscall.Recvfrom(sock.queues[queue], buf, 0)


### PR DESCRIPTION
This resolves #59 by allowing the user to send a `SIGHUP` to the quantum process which will reload both the binary and configuration. The file descriptors used for the TUN interface and backend sockets, are transparently passed to the new process, ensuring packets are not dropped during the transition.