### PR TITLE
Renamed inet module to device 

### DIFF
--- a/bin/quantum-test.yml
+++ b/bin/quantum-test.yml
@@ -1,6 +1,6 @@
 ---
 conf-file: "bin/quantum-test.yml"
-interface-name: "woot"
+device-name: "woot"
 private-ip: "10.1.1.1"
 public-ip: "10.2.2.2"
 listen-address: "10.2.2.2"

--- a/common/common.go
+++ b/common/common.go
@@ -6,8 +6,8 @@ import (
 )
 
 const (
-	// RealInterfaceNameEnv is the environment variable the the real interface name is stored for reloads.
-	RealDeviceNameEnv = "_QUANTUM_REAL_INTERFACE_NAME"
+	// RealDeviceNameEnv is the environment variable the the real device name is stored for reloads.
+	RealDeviceNameEnv = "_QUANTUM_REAL_DEVICE_NAME_"
 )
 
 const (

--- a/common/common.go
+++ b/common/common.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	// RealInterfaceNameEnv is the environment variable the the real interface name is stored for reloads.
-	RealInterfaceNameEnv = "_QUANTUM_REAL_INTERFACE_NAME"
+	RealDeviceNameEnv = "_QUANTUM_REAL_INTERFACE_NAME"
 )
 
 const (

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -84,7 +84,7 @@ func TestIncrementIP(t *testing.T) {
 }
 
 func TestNewConfig(t *testing.T) {
-	os.Setenv("QUANTUM_INTERFACE_NAME", "different")
+	os.Setenv("QUANTUM_DEVICE_NAME", "different")
 	os.Setenv("QUANTUM_LISTEN_PORT", "1")
 	os.Setenv("QUANTUM_CONF_FILE", confFile)
 	os.Setenv("QUANTUM_PID_FILE", "../quantum.pid")
@@ -97,8 +97,8 @@ func TestNewConfig(t *testing.T) {
 	if cfg == nil {
 		t.Fatal("NewConfig returned a blank config")
 	}
-	if cfg.InterfaceName != "different" {
-		t.Fatalf("NewConfig didn't pick up the environment variable replacement for InterfaceName")
+	if cfg.DeviceName != "different" {
+		t.Fatalf("NewConfig didn't pick up the environment variable replacement for DeviceName")
 	}
 	if cfg.ListenPort != 1 {
 		t.Fatalf("NewConfig didn't pick up the environment variable replacement for ListenPort")

--- a/common/config.go
+++ b/common/config.go
@@ -37,42 +37,42 @@ var (
 
 // Config handles marshalling user supplied configuration data
 type Config struct {
-	ConfFile          string            `skip:"false"  type:"string"    short:"c"    long:"conf-file"         default:""                      description:"The configuration file to use to configure quantum."`
-	InterfaceName     string            `skip:"false"  type:"string"    short:"i"    long:"interface-name"    default:"quantum%d"             description:"The name to give the TUN interface quantum uses, append '%d' to have auto incrementing names."`
-	NumWorkers        int               `skip:"false"  type:"int"       short:"n"    long:"workers"           default:"0"                     description:"The number of quantum workers to use, set to 0 for a worker per available cpu core."`
-	PrivateIP         net.IP            `skip:"false"  type:"ip"        short:"ip"   long:"private-ip"        default:""                      description:"The private ip address to assign this quantum instance."`
-	ListenIP          net.IP            `skip:"false"  type:"ip"        short:"lip"  long:"listen-ip"         default:""                      description:"The local server ip to listen on, leave blank of automatic association."`
-	ListenPort        int               `skip:"false"  type:"int"       short:"p"    long:"listen-port"       default:"1099"                  description:"The local server port to listen on."`
-	PublicIPv4        net.IP            `skip:"false"  type:"ip"        short:"4"    long:"public-v4"         default:""                      description:"The public ipv4 address to associate with this quantum instance, leave blank for automatic association."`
-	PublicIPv6        net.IP            `skip:"false"  type:"ip"        short:"6"    long:"public-v6"         default:""                      description:"The public ipv6 address to associate with this quantum instance, leave blank for automatic association."`
-	Prefix            string            `skip:"false"  type:"string"    short:"pr"   long:"prefix"            default:"quantum"               description:"The prefix to store quantum configuration data under in the backend key/value store."`
-	DataDir           string            `skip:"false"  type:"string"    short:"d"    long:"data-dir"          default:"/var/lib/quantum"      description:"The directory to store local quantum state to."`
-	PidFile           string            `skip:"false"  type:"string"    short:"pf"   long:"pid-file"          default:"/var/run/quantum.pid"  description:"The pid file to use for tracking rolling restarts."`
-	SyncInterval      time.Duration     `skip:"false"  type:"duration"  short:"si"   long:"sync-interval"     default:"60s"                   description:"The interval of full backend syncs."`
-	RefreshInterval   time.Duration     `skip:"false"  type:"duration"  short:"ri"   long:"refresh-interval"  default:"120s"                  description:"The interval of dhcp lease refreshes."`
-	Datastore         string            `skip:"false"  type:"string"    short:"ds"   long:"datastore"         default:"etcd"                  description:"The type of backend key/value store, this should be 'etcd' or 'consul'."`
-	Endpoints         []string          `skip:"false"  type:"list"      short:"e"    long:"endpoints"         default:"127.0.0.1:2379"        description:"A comma delimited list of backend key/value store endpoints, in 'IPADDR:PORT' syntax."`
-	Username          string            `skip:"false"  type:"string"    short:"u"    long:"username"          default:""                      description:"The username to use for authentication with the backend datastore."`
-	Password          string            `skip:"false"  type:"string"    short:"pw"   long:"password"          default:""                      description:"The password to use for authentication with the backend datastore."`
-	TLSSkipVerify     bool              `skip:"false"  type:"bool"      short:"tsv"  long:"tls-skip-verify"   default:"false"                 description:"Whether or not to authenticate the TLS certificates of the backend key/value store."`
-	TLSCA             string            `skip:"false"  type:"string"    short:"tca"  long:"tls-ca-cert"       default:""                      description:"The TLS CA certificate to authenticate the TLS certificates of the backend key/value store certificates."`
-	TLSCert           string            `skip:"false"  type:"string"    short:"tc"   long:"tls-cert"          default:""                      description:"The TLS client certificate to use to authenticate with the backend key/value store."`
-	TLSKey            string            `skip:"false"  type:"string"    short:"tk"   long:"tls-key"           default:""                      description:"The TLS client key to use to authenticate with the backend key/value store."`
-	StatsRoute        string            `skip:"false"  type:"string"    short:"sr"   long:"stats-route"       default:"/stats"                description:"The api route to serve statistics data from."`
-	StatsPort         int               `skip:"false"  type:"int"       short:"sp"   long:"stats-port"        default:"1099"                  description:"The api server port."`
-	StatsAddress      string            `skip:"false"  type:"string"    short:"sa"   long:"stats-address"     default:""                      description:"The api server address."`
-	RealInterfaceName string            `skip:"true"`
-	ReuseFDS          bool              `skip:"true"`
-	MachineID         string            `skip:"true"`
-	AuthEnabled       bool              `skip:"true"`
-	TLSEnabled        bool              `skip:"true"`
-	IsIPv4Enabled     bool              `skip:"true"`
-	IsIPv6Enabled     bool              `skip:"true"`
-	ListenAddr        syscall.Sockaddr  `skip:"true"`
-	NetworkConfig     *NetworkConfig    `skip:"true"`
-	PrivateKey        []byte            `skip:"true"`
-	PublicKey         []byte            `skip:"true"`
-	fileData          map[string]string `skip:"true"`
+	ConfFile        string            `skip:"false"  type:"string"    short:"c"    long:"conf-file"         default:""                      description:"The configuration file to use to configure quantum."`
+	DeviceName      string            `skip:"false"  type:"string"    short:"i"    long:"device-name"       default:"quantum%d"             description:"The name to give the TUN device quantum uses, append '%d' to have auto incrementing names."`
+	NumWorkers      int               `skip:"false"  type:"int"       short:"n"    long:"workers"           default:"0"                     description:"The number of quantum workers to use, set to 0 for a worker per available cpu core."`
+	PrivateIP       net.IP            `skip:"false"  type:"ip"        short:"ip"   long:"private-ip"        default:""                      description:"The private ip address to assign this quantum instance."`
+	ListenIP        net.IP            `skip:"false"  type:"ip"        short:"lip"  long:"listen-ip"         default:""                      description:"The local server ip to listen on, leave blank of automatic association."`
+	ListenPort      int               `skip:"false"  type:"int"       short:"p"    long:"listen-port"       default:"1099"                  description:"The local server port to listen on."`
+	PublicIPv4      net.IP            `skip:"false"  type:"ip"        short:"4"    long:"public-v4"         default:""                      description:"The public ipv4 address to associate with this quantum instance, leave blank for automatic association."`
+	PublicIPv6      net.IP            `skip:"false"  type:"ip"        short:"6"    long:"public-v6"         default:""                      description:"The public ipv6 address to associate with this quantum instance, leave blank for automatic association."`
+	Prefix          string            `skip:"false"  type:"string"    short:"pr"   long:"prefix"            default:"quantum"               description:"The prefix to store quantum configuration data under in the backend key/value store."`
+	DataDir         string            `skip:"false"  type:"string"    short:"d"    long:"data-dir"          default:"/var/lib/quantum"      description:"The directory to store local quantum state to."`
+	PidFile         string            `skip:"false"  type:"string"    short:"pf"   long:"pid-file"          default:"/var/run/quantum.pid"  description:"The pid file to use for tracking rolling restarts."`
+	SyncInterval    time.Duration     `skip:"false"  type:"duration"  short:"si"   long:"sync-interval"     default:"60s"                   description:"The interval of full backend syncs."`
+	RefreshInterval time.Duration     `skip:"false"  type:"duration"  short:"ri"   long:"refresh-interval"  default:"120s"                  description:"The interval of dhcp lease refreshes."`
+	Datastore       string            `skip:"false"  type:"string"    short:"ds"   long:"datastore"         default:"etcd"                  description:"The type of backend key/value store, this should be 'etcd' or 'consul'."`
+	Endpoints       []string          `skip:"false"  type:"list"      short:"e"    long:"endpoints"         default:"127.0.0.1:2379"        description:"A comma delimited list of backend key/value store endpoints, in 'IPADDR:PORT' syntax."`
+	Username        string            `skip:"false"  type:"string"    short:"u"    long:"username"          default:""                      description:"The username to use for authentication with the backend datastore."`
+	Password        string            `skip:"false"  type:"string"    short:"pw"   long:"password"          default:""                      description:"The password to use for authentication with the backend datastore."`
+	TLSSkipVerify   bool              `skip:"false"  type:"bool"      short:"tsv"  long:"tls-skip-verify"   default:"false"                 description:"Whether or not to authenticate the TLS certificates of the backend key/value store."`
+	TLSCA           string            `skip:"false"  type:"string"    short:"tca"  long:"tls-ca-cert"       default:""                      description:"The TLS CA certificate to authenticate the TLS certificates of the backend key/value store certificates."`
+	TLSCert         string            `skip:"false"  type:"string"    short:"tc"   long:"tls-cert"          default:""                      description:"The TLS client certificate to use to authenticate with the backend key/value store."`
+	TLSKey          string            `skip:"false"  type:"string"    short:"tk"   long:"tls-key"           default:""                      description:"The TLS client key to use to authenticate with the backend key/value store."`
+	StatsRoute      string            `skip:"false"  type:"string"    short:"sr"   long:"stats-route"       default:"/stats"                description:"The api route to serve statistics data from."`
+	StatsPort       int               `skip:"false"  type:"int"       short:"sp"   long:"stats-port"        default:"1099"                  description:"The api server port."`
+	StatsAddress    string            `skip:"false"  type:"string"    short:"sa"   long:"stats-address"     default:""                      description:"The api server address."`
+	RealDeviceName  string            `skip:"true"`
+	ReuseFDS        bool              `skip:"true"`
+	MachineID       string            `skip:"true"`
+	AuthEnabled     bool              `skip:"true"`
+	TLSEnabled      bool              `skip:"true"`
+	IsIPv4Enabled   bool              `skip:"true"`
+	IsIPv6Enabled   bool              `skip:"true"`
+	ListenAddr      syscall.Sockaddr  `skip:"true"`
+	NetworkConfig   *NetworkConfig    `skip:"true"`
+	PrivateKey      []byte            `skip:"true"`
+	PublicKey       []byte            `skip:"true"`
+	fileData        map[string]string `skip:"true"`
 }
 
 func (cfg *Config) cliArg(short, long string, isFlag bool) (string, bool) {
@@ -276,8 +276,8 @@ func (cfg *Config) computeArgs() error {
 	}
 	cfg.MachineID = hex.EncodeToString(machineID)
 
-	cfg.RealInterfaceName = os.Getenv(RealInterfaceNameEnv)
-	if cfg.RealInterfaceName != "" {
+	cfg.RealDeviceName = os.Getenv(RealDeviceNameEnv)
+	if cfg.RealDeviceName != "" {
 		cfg.ReuseFDS = true
 	}
 

--- a/device/device.go
+++ b/device/device.go
@@ -1,4 +1,4 @@
-package inet
+package device
 
 import (
 	"github.com/Supernomad/quantum/common"
@@ -7,12 +7,12 @@ import (
 )
 
 const (
-	// TUNInterface interface type
-	TUNInterface int = 0
-	// TAPInterface interface type
-	TAPInterface int = 1
-	// MOCKInterface interface type
-	MOCKInterface int = 2
+	// TUNDevice interface type
+	TUNDevice int = 0
+	// TAPDevice interface type
+	TAPDevice int = 1
+	// MOCKDevice interface type
+	MOCKDevice int = 2
 
 	ifNameSize    = 16
 	iffTun        = 0x0001
@@ -26,28 +26,26 @@ type ifReq struct {
 	Flags uint16
 }
 
-// Interface is a generic multi-queue network interface
-type Interface interface {
+// Device is a generic multi-queue network device
+type Device interface {
 	Name() string
 	Read(buf []byte, queue int) (*common.Payload, bool)
 	Write(payload *common.Payload, queue int) bool
 	Open() error
 	Close() error
-	GetFDs() []int
+	Queues() []int
 }
 
-// New Interface object
-func New(kind int, cfg *common.Config) Interface {
+// New Device object
+func New(kind int, cfg *common.Config) Device {
 	switch kind {
-	case TUNInterface:
+	case TUNDevice:
 		return newTUN(cfg)
-	case MOCKInterface:
-		return newMock(cfg)
 	}
 	return nil
 }
 
-func initInterface(name, src string, networkCfg *common.NetworkConfig) error {
+func initDevice(name, src string, networkCfg *common.NetworkConfig) error {
 	link, err := netlink.LinkByName(name)
 	if err != nil {
 		return err

--- a/device/device.go
+++ b/device/device.go
@@ -7,11 +7,11 @@ import (
 )
 
 const (
-	// TUNDevice interface type
+	// TUNDevice type
 	TUNDevice int = 0
-	// TAPDevice interface type
+	// TAPDevice type
 	TAPDevice int = 1
-	// MOCKDevice interface type
+	// MOCKDevice type
 	MOCKDevice int = 2
 
 	ifNameSize    = 16

--- a/device/device.go
+++ b/device/device.go
@@ -41,6 +41,8 @@ func New(kind int, cfg *common.Config) Device {
 	switch kind {
 	case TUNDevice:
 		return newTUN(cfg)
+	case MOCKDevice:
+		return newMock(cfg)
 	}
 	return nil
 }

--- a/device/mock.go
+++ b/device/mock.go
@@ -1,40 +1,40 @@
-package inet
+package device
 
 import (
 	"github.com/Supernomad/quantum/common"
 )
 
-// Mock interface
+// Mock device
 type Mock struct {
 }
 
-// Name of the interface
+// Name of the device
 func (mock *Mock) Name() string {
-	return "Mocked Interface"
+	return "Mocked Device"
 }
 
-// Read a packet off the interface
+// Read a packet off the device
 func (mock *Mock) Read(buf []byte, queue int) (*common.Payload, bool) {
 	return common.NewTunPayload(buf, common.MTU), true
 }
 
-// Write a packet to the interface
+// Write a packet to the device
 func (mock *Mock) Write(payload *common.Payload, queue int) bool {
 	return true
 }
 
-// Open the interface
+// Open the device
 func (mock *Mock) Open() error {
 	return nil
 }
 
-// Close the interface
+// Close the device
 func (mock *Mock) Close() error {
 	return nil
 }
 
-// GetFDs will return the underlying queue fds
-func (mock *Mock) GetFDs() []int {
+// Queues will return the underlying queue fds
+func (mock *Mock) Queues() []int {
 	return nil
 }
 

--- a/device/tun.go
+++ b/device/tun.go
@@ -1,4 +1,4 @@
-package inet
+package device
 
 import (
 	"github.com/Supernomad/quantum/common"
@@ -7,7 +7,7 @@ import (
 	"unsafe"
 )
 
-// Tun interface
+// Tun device
 type Tun struct {
 	name   string
 	queues []int
@@ -31,12 +31,12 @@ func (tun *Tun) Open() error {
 			tun.name = ifName
 		} else {
 			tun.queues[i] = 3 + i
-			tun.name = tun.cfg.RealInterfaceName
+			tun.name = tun.cfg.RealDeviceName
 		}
 	}
 
 	if !tun.cfg.ReuseFDS {
-		err := initInterface(tun.name, tun.cfg.PrivateIP.String(), tun.cfg.NetworkConfig)
+		err := initDevice(tun.name, tun.cfg.PrivateIP.String(), tun.cfg.NetworkConfig)
 		if err != nil {
 			return err
 		}
@@ -54,8 +54,8 @@ func (tun *Tun) Close() error {
 	return nil
 }
 
-// GetFDs will return the underlying queue fds
-func (tun *Tun) GetFDs() []int {
+// Queues will return the underlying queue fds
+func (tun *Tun) Queues() []int {
 	return tun.queues
 }
 
@@ -77,9 +77,9 @@ func (tun *Tun) Write(payload *common.Payload, queue int) bool {
 	return true
 }
 
-func newTUN(cfg *common.Config) Interface {
+func newTUN(cfg *common.Config) Device {
 	queues := make([]int, cfg.NumWorkers)
-	name := cfg.InterfaceName
+	name := cfg.DeviceName
 
 	return &Tun{name: name, cfg: cfg, queues: queues}
 }

--- a/workers/incoming.go
+++ b/workers/incoming.go
@@ -5,7 +5,7 @@ import (
 	"github.com/Supernomad/quantum/agg"
 	"github.com/Supernomad/quantum/backend"
 	"github.com/Supernomad/quantum/common"
-	"github.com/Supernomad/quantum/inet"
+	"github.com/Supernomad/quantum/device"
 	"github.com/Supernomad/quantum/socket"
 )
 
@@ -13,7 +13,7 @@ import (
 type Incoming struct {
 	cfg        *common.Config
 	aggregator *agg.Agg
-	tunnel     inet.Interface
+	dev        device.Device
 	sock       socket.Socket
 	store      backend.Backend
 	stop       bool
@@ -73,7 +73,7 @@ func (incoming *Incoming) pipeline(buf []byte, queue int) bool {
 		return ok
 	}
 	incoming.stats(false, queue, payload, mapping)
-	return incoming.tunnel.Write(payload, queue)
+	return incoming.dev.Write(payload, queue)
 }
 
 // Start handling packets
@@ -92,11 +92,11 @@ func (incoming *Incoming) Stop() {
 }
 
 // NewIncoming object
-func NewIncoming(cfg *common.Config, aggregator *agg.Agg, store backend.Backend, tunnel inet.Interface, sock socket.Socket) *Incoming {
+func NewIncoming(cfg *common.Config, aggregator *agg.Agg, store backend.Backend, dev device.Device, sock socket.Socket) *Incoming {
 	return &Incoming{
 		cfg:        cfg,
 		aggregator: aggregator,
-		tunnel:     tunnel,
+		dev:        dev,
 		sock:       sock,
 		store:      store,
 		stop:       false,

--- a/workers/outgoing.go
+++ b/workers/outgoing.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Supernomad/quantum/agg"
 	"github.com/Supernomad/quantum/backend"
 	"github.com/Supernomad/quantum/common"
-	"github.com/Supernomad/quantum/inet"
+	"github.com/Supernomad/quantum/device"
 	"github.com/Supernomad/quantum/socket"
 )
 
@@ -14,7 +14,7 @@ import (
 type Outgoing struct {
 	cfg        *common.Config
 	aggregator *agg.Agg
-	tunnel     inet.Interface
+	dev        device.Device
 	sock       socket.Socket
 	store      backend.Backend
 	stop       bool
@@ -67,7 +67,7 @@ func (outgoing *Outgoing) stats(dropped bool, queue int, payload *common.Payload
 }
 
 func (outgoing *Outgoing) pipeline(buf []byte, queue int) bool {
-	payload, ok := outgoing.tunnel.Read(buf, queue)
+	payload, ok := outgoing.dev.Read(buf, queue)
 	if !ok {
 		outgoing.stats(true, queue, payload, nil)
 		return ok
@@ -102,11 +102,11 @@ func (outgoing *Outgoing) Stop() {
 }
 
 // NewOutgoing object
-func NewOutgoing(cfg *common.Config, aggregator *agg.Agg, store backend.Backend, tunnel inet.Interface, sock socket.Socket) *Outgoing {
+func NewOutgoing(cfg *common.Config, aggregator *agg.Agg, store backend.Backend, dev device.Device, sock socket.Socket) *Outgoing {
 	return &Outgoing{
 		cfg:        cfg,
 		aggregator: aggregator,
-		tunnel:     tunnel,
+		dev:        dev,
 		sock:       sock,
 		store:      store,
 		stop:       false,

--- a/workers/workers_test.go
+++ b/workers/workers_test.go
@@ -16,7 +16,7 @@ import (
 var (
 	outgoing  *Outgoing
 	incoming  *Incoming
-	tun       inet.Interface
+	dev       device.Device
 	sock      socket.Socket
 	store     *backend.Mock
 	privateIP = "10.1.1.1"
@@ -32,7 +32,7 @@ func init() {
 	ipv6 := net.ParseIP("dead::beef")
 
 	store = &backend.Mock{}
-	tun = inet.New(inet.MOCKInterface, nil)
+	dev = device.New(device.MOCKDevice, nil)
 	sock = socket.New(socket.MOCKSocket, nil)
 
 	key := make([]byte, 32)
@@ -55,6 +55,6 @@ func init() {
 	wg.Add(1)
 	aggregator.Start(wg)
 
-	incoming = NewIncoming(&common.Config{NumWorkers: 1, PrivateIP: ip, IsIPv6Enabled: true, IsIPv4Enabled: true}, aggregator, store, tun, sock)
-	outgoing = NewOutgoing(&common.Config{NumWorkers: 1, PrivateIP: ip, IsIPv6Enabled: true, IsIPv4Enabled: true}, aggregator, store, tun, sock)
+	incoming = NewIncoming(&common.Config{NumWorkers: 1, PrivateIP: ip, IsIPv6Enabled: true, IsIPv4Enabled: true}, aggregator, store, dev, sock)
+	outgoing = NewOutgoing(&common.Config{NumWorkers: 1, PrivateIP: ip, IsIPv6Enabled: true, IsIPv4Enabled: true}, aggregator, store, dev, sock)
 }

--- a/workers/workers_test.go
+++ b/workers/workers_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/Supernomad/quantum/agg"
 	"github.com/Supernomad/quantum/backend"
 	"github.com/Supernomad/quantum/common"
-	"github.com/Supernomad/quantum/inet"
+	"github.com/Supernomad/quantum/device"
 	"github.com/Supernomad/quantum/socket"
 	"net"
 	"sync"


### PR DESCRIPTION
This is purely a cosmetic change to make the code a bit more readable and understandable at a glance. Really it comes down to `inet` not making much sense as the name, and `device` depicting what the module is used for, network device interaction, in much clearer way.