### PR TITLE
Per host encryption

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 # Licensed under the MPL-2.0, for details see https://github.com/Supernomad/quantum/blob/master/LICENSE
 
 PUSH_COVERAGE=""
+BENC_MAX_PROCS=1
 
 setup_dev: build_deps gen_certs gen_docker_network build_docker
 
@@ -49,7 +50,7 @@ race:
 
 bench:
 	@echo "Running unit tests with benchmarking enabled..."
-	@go test -bench . -benchmem './...'
+	@GOMAXPROCS=$(BENC_MAX_PROCS) go test -bench . -benchmem './...'
 
 unit:
 	@echo "Running unit tests with benchmarking disabled..."

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Licensed under the MPL-2.0, for details see https://github.com/Supernomad/quantum/blob/master/LICENSE
 
 PUSH_COVERAGE=""
-BENC_MAX_PROCS=1
+BENCH_MAX_PROCS=1
 
 setup_dev: build_deps gen_certs gen_docker_network build_docker
 
@@ -50,7 +50,7 @@ race:
 
 bench:
 	@echo "Running unit tests with benchmarking enabled..."
-	@GOMAXPROCS=$(BENC_MAX_PROCS) go test -bench . -benchmem './...'
+	@GOMAXPROCS=$(BENCH_MAX_PROCS) go test -bench . -benchmem './...'
 
 unit:
 	@echo "Running unit tests with benchmarking disabled..."

--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ $ make dev
 # Start up the docker test bench
 $ docker-compose up -d
 # Wait a few seconds for initialization to complete
-# Check on the status of the different quantum instances
+# Check on the status of the different quantum containers
 $ docker-compose logs quantum0 quantum1 quantum2
 # Run ping to ensure connectivity over quantum
 $ docker exec -it quantum1 ping 10.99.0.1
 $ docker exec -it quantum2 ping 10.99.0.1
 ```
-After running the above you will have a single etcd instance and three quantum instances running. The three quantum instances are configured to run a quantum network `10.99.0.0/16`, with `quantum0` having a statically defined private ip `10.99.0.1` and `quantum1`/`quantum2` having DHCP defined private ip addresses.
+After running the above you will have a single etcd container and three quantum containers running. The three quantum containers are configured to run a quantum network `10.99.0.0/16`, with `quantum0` having a statically defined private ip `10.99.0.1` and `quantum1`/`quantum2` having DHCP defined private ip addresses.
 
 #### Testing
 To run basic unit testing and builds execute:
@@ -79,13 +79,13 @@ To run code level benchmarks execute:
 
 ``` shell
 # This must be executed as root due to the need to create a tun interface see device/device_test.go for details
-$ sudo -i -E bash -c "cd $GOPATH/src/github.com/Supernomad/quantum && make bench"
+$ sudo -i bash -c "cd $GOPATH/src/github.com/Supernomad/quantum; PATH='$PATH' GOPATH='$GOPATH' make bench"
 ```
 
-To do basic bandwidth based testing the `quantum` containers all have iperf3 installed. For example to test how much through put `quantum0` can handle from both `quantum1`/`quantum2`:
+To do basic bandwidth based testing the `quantum` containers all have iperf3 installed. For example to test how much throughput `quantum0` can handle from both `quantum1`/`quantum2`:
 
 ``` shell
-# Assuming the three development quantum instances are started
+# Assuming the three development quantum containers are started
 # Start three shells
 
 # In first shell start iperf3 server

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -189,28 +189,32 @@ func TestEcdh(t *testing.T) {
 }
 
 func TestNewMapping(t *testing.T) {
-	privateIP := net.ParseIP("0.0.0.0")
-	publicip := net.ParseIP("1.1.1.1")
-	publicip6 := net.ParseIP("dead::beef")
-	publicport := 80
-	publicKey := make([]byte, 32)
-	machineID := "123456"
+	cfg := &Config{
+		PrivateIP:  net.ParseIP("0.0.0.0"),
+		PublicIPv4: net.ParseIP("1.1.1.1"),
+		PublicIPv6: net.ParseIP("dead::beef"),
+		ListenPort: 80,
+		PublicKey:  make([]byte, 32),
+		MachineID:  "123456",
+	}
 
-	actual := NewMapping(machineID, privateIP, publicip, publicip6, publicport, publicKey)
-	if !testEq(actual.IPv4, publicip) || !testEq(actual.IPv6, publicip6) || actual.Port != publicport || !testEq(actual.PrivateIP, privateIP) || !testEq(actual.PublicKey, publicKey) {
+	actual := NewMapping(cfg)
+	if !testEq(actual.IPv4, cfg.PublicIPv4) || !testEq(actual.IPv6, cfg.PublicIPv6) || actual.Port != cfg.ListenPort || !testEq(actual.PrivateIP, cfg.PrivateIP) || !testEq(actual.PublicKey, cfg.PublicKey) {
 		t.Fatalf("NewMapping did not return the right value, got: %v", actual)
 	}
 }
 
 func TestParseMapping(t *testing.T) {
-	privateIP := net.ParseIP("0.0.0.0")
-	publicip := net.ParseIP("1.1.1.1")
-	publicip6 := net.ParseIP("dead::beef")
-	publicport := 80
-	publicKey := make([]byte, 32)
-	machineID := "123456"
+	cfg := &Config{
+		PrivateIP:  net.ParseIP("0.0.0.0"),
+		PublicIPv4: net.ParseIP("1.1.1.1"),
+		PublicIPv6: net.ParseIP("dead::beef"),
+		ListenPort: 80,
+		PublicKey:  make([]byte, 32),
+		MachineID:  "123456",
+	}
 
-	expected := NewMapping(machineID, privateIP, publicip, publicip6, publicport, publicKey)
+	expected := NewMapping(cfg)
 	actual, err := ParseMapping(expected.String(), make([]byte, 32))
 	if err != nil {
 		t.Fatalf("Error occurred during test: %s", err)

--- a/common/config.go
+++ b/common/config.go
@@ -51,6 +51,7 @@ The only exceptions to the above are the two special cli argments '-h'|'--help' 
 */
 type Config struct {
 	ConfFile        string            `skip:"false"  type:"string"    short:"c"    long:"conf-file"         default:""                      description:"The configuration file to use to configure quantum."`
+	Unencrypted     bool              `skip:"false"  type:"bool"      short:"ue"   long:"unencrypted"       default:"false"                 description:"Whether or not to authenticate the TLS certificates of the backend key/value store."`
 	DeviceName      string            `skip:"false"  type:"string"    short:"i"    long:"device-name"       default:"quantum%d"             description:"The name to give the TUN device quantum uses, append '%d' to have auto incrementing names."`
 	NumWorkers      int               `skip:"false"  type:"int"       short:"n"    long:"workers"           default:"0"                     description:"The number of quantum workers to use, set to 0 for a worker per available cpu core."`
 	PrivateIP       net.IP            `skip:"false"  type:"ip"        short:"ip"   long:"private-ip"        default:""                      description:"The private ip address to assign this quantum instance."`

--- a/common/ipHandler.go
+++ b/common/ipHandler.go
@@ -54,5 +54,5 @@ func GenerateLocalMapping(cfg *Config, mappings map[uint32]*Mapping) (*Mapping, 
 		return nil, errors.New("statically assigned private ip address belongs to another server")
 	}
 
-	return NewMapping(cfg.MachineID, cfg.PrivateIP, cfg.PublicIPv4, cfg.PublicIPv6, cfg.ListenPort, cfg.PublicKey), nil
+	return NewMapping(cfg), nil
 }

--- a/common/mapping.go
+++ b/common/mapping.go
@@ -31,7 +31,10 @@ type Mapping struct {
 	// The port where quantum is listening for remote packets.
 	Port int `json:"port"`
 
-	// The AEAD object to use for encryption/decryption of packets
+	// Whether or not the node requires encrypted traffic.
+	Unencrypted bool `json:"unencrypted"`
+
+	// The AEAD cipher object to use for encryption/decryption of packets
 	Cipher cipher.AEAD `json:"-"`
 
 	// The ipv4 syscall.Sockaddr object for sending data to the node represented by this mapping.
@@ -87,13 +90,14 @@ func ParseMapping(str string, privkey []byte) (*Mapping, error) {
 }
 
 // NewMapping generates a new basic Mapping with no cryptographic metadata.
-func NewMapping(machineID string, privateIP, publicV4, publicV6 net.IP, port int, pubkey []byte) *Mapping {
+func NewMapping(cfg *Config) *Mapping {
 	return &Mapping{
-		MachineID: machineID,
-		IPv4:      publicV4,
-		IPv6:      publicV6,
-		Port:      port,
-		PrivateIP: privateIP,
-		PublicKey: pubkey,
+		MachineID:   cfg.MachineID,
+		Unencrypted: cfg.Unencrypted,
+		IPv4:        cfg.PublicIPv4,
+		IPv6:        cfg.PublicIPv6,
+		Port:        cfg.ListenPort,
+		PrivateIP:   cfg.PrivateIP,
+		PublicKey:   cfg.PublicKey,
 	}
 }

--- a/dist/quantum.yml
+++ b/dist/quantum.yml
@@ -6,6 +6,9 @@
 endpoints: "etcd.quantum.dev:2379"
 public-ip: "172.18.0.5"
 
+unencrypted: true
+trusted: "10.99.2.0/24"
+
 tls-ca-cert: "/etc/quantum/ssl/certs/ca.crt"
 tls-cert: "/etc/quantum/ssl/certs/quantum2.quantum.dev.crt"
 tls-key: "/etc/quantum/ssl/keys/quantum2.quantum.dev.key"

--- a/dist/systemd/quantum.service
+++ b/dist/systemd/quantum.service
@@ -5,12 +5,12 @@ After=network.target
 [Service]
 Type=simple
 Restart=on-failure
-EnvironmentFile=/etc/default/quantum
-EnvironmentFile=/etc/quantum/quantum.env
+EnvironmentFile=-/etc/default/quantum
+EnvironmentFile=-/etc/quantum/quantum.env
 PIDFile=/var/run/quantum.pid
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStop=/bin/kill -TERM $MAINPID
-ExecStart=/usr/sbin/quantum --conf-file /etc/quantum/quantum.yml
+ExecStart=/usr/sbin/quantum
 
 [Install]
 WantedBy=default.target

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       - quantum1:/var/lib/quantum/
     environment:
       QUANTUM_UNENCRYPTED: "true"
+      QUANTUM_TRUSTED: "10.99.2.1/32,10.99.2.2"
       QUANTUM_ENDPOINTS: "etcd.quantum.dev:2379"
       QUANTUM_PUBLIC_IP: "172.18.0.3"
       QUANTUM_TLS_CA_CERT: "/etc/quantum/ssl/certs/ca.crt"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       - $GOPATH/src/github.com/Supernomad/quantum/dist/ssl/keys/:/etc/quantum/ssl/keys/:ro
       - quantum1:/var/lib/quantum/
     environment:
+      QUANTUM_UNENCRYPTED: "true"
       QUANTUM_ENDPOINTS: "etcd.quantum.dev:2379"
       QUANTUM_PUBLIC_IP: "172.18.0.3"
       QUANTUM_TLS_CA_CERT: "/etc/quantum/ssl/certs/ca.crt"

--- a/workers/incoming.go
+++ b/workers/incoming.go
@@ -35,6 +35,11 @@ func (incoming *Incoming) resolve(payload *common.Payload) (*common.Payload, *co
 }
 
 func (incoming *Incoming) unseal(payload *common.Payload, mapping *common.Mapping) (*common.Payload, bool) {
+	// This local node and the remote node are unencrypted so traffic between them should be considered "plain text"
+	if incoming.cfg.Unencrypted && mapping.Unencrypted {
+		return payload, true
+	}
+
 	_, err := mapping.Cipher.Open(payload.Packet[:0], payload.Nonce, payload.Packet, payload.IPAddress)
 	if err != nil {
 		return nil, false

--- a/workers/incoming.go
+++ b/workers/incoming.go
@@ -35,8 +35,8 @@ func (incoming *Incoming) resolve(payload *common.Payload) (*common.Payload, *co
 }
 
 func (incoming *Incoming) unseal(payload *common.Payload, mapping *common.Mapping) (*common.Payload, bool) {
-	// This local node and the remote node are unencrypted so traffic between them should be considered "plain text"
-	if incoming.cfg.Unencrypted && mapping.Unencrypted {
+	// This local node and the remote node are both unencrypted, and the remote node is trusted, so traffic between them should be considered "plain text"
+	if incoming.cfg.Unencrypted && mapping.Unencrypted && isTrusted(incoming.cfg, mapping) {
 		return payload, true
 	}
 

--- a/workers/outgoing.go
+++ b/workers/outgoing.go
@@ -44,8 +44,8 @@ func (outgoing *Outgoing) resolve(payload *common.Payload) (*common.Payload, *co
 }
 
 func (outgoing *Outgoing) seal(payload *common.Payload, mapping *common.Mapping) (*common.Payload, bool) {
-	// This local node and the remote node are unencrypted so traffic between them should be considered "plain text"
-	if outgoing.cfg.Unencrypted && mapping.Unencrypted {
+	// This local node and the remote node are both unencrypted, and the remote node is trusted, so traffic between them should be considered "plain text"
+	if outgoing.cfg.Unencrypted && mapping.Unencrypted && isTrusted(outgoing.cfg, mapping) {
 		return payload, true
 	}
 

--- a/workers/outgoing.go
+++ b/workers/outgoing.go
@@ -44,6 +44,11 @@ func (outgoing *Outgoing) resolve(payload *common.Payload) (*common.Payload, *co
 }
 
 func (outgoing *Outgoing) seal(payload *common.Payload, mapping *common.Mapping) (*common.Payload, bool) {
+	// This local node and the remote node are unencrypted so traffic between them should be considered "plain text"
+	if outgoing.cfg.Unencrypted && mapping.Unencrypted {
+		return payload, true
+	}
+
 	_, err := rand.Read(payload.Nonce)
 	if err != nil {
 		return nil, false

--- a/workers/workers.go
+++ b/workers/workers.go
@@ -5,3 +5,20 @@
 Package workers contains the structs and logic to handle routing, encrypting, and analyzing traffic over the quantum network. Each worker handles one direction of network traffic, either incoming traffic from remote nodes or outgoing traffic destined for remote nodes.
 */
 package workers
+
+import (
+	"github.com/Supernomad/quantum/common"
+)
+
+func isTrusted(cfg *common.Config, mapping *common.Mapping) bool {
+	if cfg.TrustedNetworks == nil {
+		return false
+	}
+
+	for i := 0; i < len(cfg.TrustedNetworks); i++ {
+		if cfg.TrustedNetworks[i].Contains(mapping.PrivateIP) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This enables the ability to turn on and off encryption on a per node basis. This PR overcomes initial issues with opening up potential exploits in the packet pipeline, by enforcing that both nodes communicating must be locally configured as unencrypted, and be configured to trust the opposite node.

The following conditions must be met in order to accept/transmit clear text traffic:
- The local node is configured explicitly to be unencrypted.
- The remote node is configured explicitly to be unencrypted.
- Both nodes consider the other trusted