### PR TITLE
User supplied default network config

### DIFF
--- a/common/common_test.go
+++ b/common/common_test.go
@@ -191,6 +191,21 @@ func TestParseMapping(t *testing.T) {
 }
 
 func TestParseNetworkConfig(t *testing.T) {
+	defaultLeaseTime, _ := time.ParseDuration("48h")
+	DefaultNetworkConfig := &NetworkConfig{
+		Backend:     "udp",
+		Network:     "10.99.0.0/16",
+		StaticRange: "10.99.0.0/23",
+		LeaseTime:   defaultLeaseTime,
+	}
+
+	baseIP, ipnet, _ := net.ParseCIDR(DefaultNetworkConfig.Network)
+	DefaultNetworkConfig.BaseIP = baseIP
+	DefaultNetworkConfig.IPNet = ipnet
+
+	_, staticNet, _ := net.ParseCIDR(DefaultNetworkConfig.StaticRange)
+	DefaultNetworkConfig.StaticNet = staticNet
+
 	actual, err := ParseNetworkConfig(DefaultNetworkConfig.Bytes())
 	if err != nil {
 		t.Fatal("ParseNetworkConfig returned an error:", err)
@@ -297,6 +312,21 @@ func TestNewLogger(t *testing.T) {
 }
 
 func TestGenerateLocalMapping(t *testing.T) {
+	defaultLeaseTime, _ := time.ParseDuration("48h")
+	DefaultNetworkConfig := &NetworkConfig{
+		Backend:     "udp",
+		Network:     "10.99.0.0/16",
+		StaticRange: "10.99.0.0/23",
+		LeaseTime:   defaultLeaseTime,
+	}
+
+	baseIP, ipnet, _ := net.ParseCIDR(DefaultNetworkConfig.Network)
+	DefaultNetworkConfig.BaseIP = baseIP
+	DefaultNetworkConfig.IPNet = ipnet
+
+	_, staticNet, _ := net.ParseCIDR(DefaultNetworkConfig.StaticRange)
+	DefaultNetworkConfig.StaticNet = staticNet
+
 	cfg := &Config{
 		PrivateIP:     net.ParseIP("10.99.0.1"),
 		PublicIPv4:    net.ParseIP("192.167.0.1"),

--- a/common/networkConfig.go
+++ b/common/networkConfig.go
@@ -10,15 +10,6 @@ import (
 	"time"
 )
 
-// DefaultNetworkConfig to use when the NetworkConfig is not specified in the backend datastore.
-var DefaultNetworkConfig *NetworkConfig
-
-const (
-	defaultBackend     = "udp"
-	defaultNetwork     = "10.99.0.0/16"
-	defaultStaticRange = "10.99.0.0/23"
-)
-
 // NetworkConfig object to represent the current network setup.
 type NetworkConfig struct {
 	// The backend to use for communication.
@@ -84,21 +75,4 @@ func (networkCfg *NetworkConfig) Bytes() []byte {
 // Bytes returns a string representation of a NetworkConfig object, if there is an error while marshalling data an empty string is returned.
 func (networkCfg *NetworkConfig) String() string {
 	return string(networkCfg.Bytes())
-}
-
-func init() {
-	defaultLeaseTime, _ := time.ParseDuration("48h")
-	DefaultNetworkConfig = &NetworkConfig{
-		Backend:     defaultBackend,
-		Network:     defaultNetwork,
-		StaticRange: defaultStaticRange,
-		LeaseTime:   defaultLeaseTime,
-	}
-
-	baseIP, ipnet, _ := net.ParseCIDR(DefaultNetworkConfig.Network)
-	DefaultNetworkConfig.BaseIP = baseIP
-	DefaultNetworkConfig.IPNet = ipnet
-
-	_, staticNet, _ := net.ParseCIDR(DefaultNetworkConfig.StaticRange)
-	DefaultNetworkConfig.StaticNet = staticNet
 }

--- a/datastore/etcd.go
+++ b/datastore/etcd.go
@@ -49,13 +49,12 @@ func (etcd *Etcd) handleNetworkConfig() error {
 			return errors.New("error retrieving the network configuration from etcd: " + err.Error())
 		}
 
-		etcd.log.Warn.Println("[ETCD]", "Using default network configuration.")
-		_, err := etcd.kapi.Set(context.Background(), etcd.key("config"), common.DefaultNetworkConfig.String(), &client.SetOptions{})
+		etcd.log.Info.Println("[ETCD]", "Using default network configuration.")
+		_, err := etcd.kapi.Set(context.Background(), etcd.key("config"), etcd.cfg.NetworkConfig.String(), &client.SetOptions{})
 		if err != nil {
 			return errors.New("error setting the default network configuration in etcd: " + err.Error())
 		}
 
-		etcd.cfg.NetworkConfig = common.DefaultNetworkConfig
 		return nil
 	}
 


### PR DESCRIPTION
Changed how the default network configuration is passed to etcd so that the user can specify the config to quantum at startup, this means that the first instance to take a lock out on etcd will be the one that sets the config cluster wide. 

This differs from the current setup which is using a hardcoded set of defaults.