### PR TITLE
Floating IPs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017 Christian Saide <Supernomad>
 # Licensed under the MPL-2.0, for details see https://github.com/Supernomad/quantum/blob/master/LICENSE
 
-.PHONY: all setup_ci setup_dev gen_certs gen_docker_network rm_docker_network build_docker ci_deps build_deps vendor_deps lib_deps compile install lint check clean release
+.PHONY: all setup_ci setup_dev gen_certs build_docker ci_deps build_deps vendor_deps lib_deps compile install lint check clean release
 
 CI=
 ifdef CI
@@ -14,19 +14,11 @@ all: lib_deps compile
 
 setup_ci: ci_deps build_deps vendor_deps gen_certs
 
-setup_dev: build_deps vendor_deps gen_certs rm_docker_network gen_docker_network build_docker
+setup_dev: build_deps vendor_deps gen_certs build_docker
 
 gen_certs:
 	@echo "Generating etcd certificates..."
 	@dist/bin/generate-tls-test-certs.sh
-
-gen_docker_network:
-	@echo "Setting up docker networks..."
-	@docker network create --ipv6 --subnet=172.18.0.0/24 --gateway=172.18.0.1 --subnet='fd00:dead:beef::/64' --gateway='fd00:dead:beef::1' quantum_dev_net
-
-rm_docker_network:
-	@echo "Removing docker networks..."
-	@docker network rm quantum_dev_net || true
 
 build_docker:
 	@echo "Building test docker container..."

--- a/Makefile
+++ b/Makefile
@@ -22,12 +22,11 @@ gen_certs:
 
 gen_docker_network:
 	@echo "Setting up docker networks..."
-	@docker network create --subnet=172.18.0.0/24 --gateway=172.18.0.1 quantum_dev_net_v4
-	@docker network create --subnet='fd00:dead:beef::/64' --gateway='fd00:dead:beef::1' --ipv6 quantum_dev_net_v6
+	@docker network create --ipv6 --subnet=172.18.0.0/24 --gateway=172.18.0.1 --subnet='fd00:dead:beef::/64' --gateway='fd00:dead:beef::1' quantum_dev_net
 
 rm_docker_network:
 	@echo "Removing docker networks..."
-	@docker network rm quantum_dev_net_v4 quantum_dev_net_v6 || true
+	@docker network rm quantum_dev_net || true
 
 build_docker:
 	@echo "Building test docker container..."
@@ -69,7 +68,7 @@ lint:
 	@fgt go fmt './...'
 	@fgt go vet './...'
 	@fgt golint './...'
-	@find . -type f -not -path "*/ssl/**/*" -and -not -path "*/vendor/**/*" | xargs fgt misspell
+	@find . -type f -not -path "*/ssl/**/*" -and -not -path "*/vendor/**/*" -and -not -path "*/.git/*" | xargs fgt misspell
 
 check: lint
 	@echo "Running tests..."

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -145,6 +145,7 @@ func testYamlConfig(t *testing.T, args []string) {
 	os.Setenv("QUANTUM_LISTEN_PORT", "1")
 	os.Setenv("QUANTUM_CONF_FILE", ymlConfFile)
 	os.Setenv("QUANTUM_PID_FILE", "../quantum.pid")
+	os.Setenv("QUANTUM_FLOATING_IPS", "10.99.1.1,10.99.1.2,hello")
 	os.Setenv("_QUANTUM_REAL_DEVICE_NAME_", "quantum0")
 
 	os.Args = append(args, "-n", "100", "--datastore-prefix", "woot", "--datastore-tls-skip-verify", "-6", "fd00:dead:beef::2", "--network", "", "--network-backend", "", "--network-lease-time", "0")
@@ -176,6 +177,15 @@ func testYamlConfig(t *testing.T, args []string) {
 	if len(cfg.Plugins) != 2 {
 		t.Fatal("NewConfig didn't pick up file replacement for Plugins")
 	}
+	if len(cfg.FloatingIPs) != 2 {
+		t.Fatal("NewConfig didn't pick up environment variable replacement for FloatingIPs")
+	}
+	if cfg.FloatingIPs[0].String() != "10.99.1.1" {
+		t.Fatal("NewConfig didn't pick up environment variable replacement value for FloatingIPs[0]")
+	}
+	if cfg.FloatingIPs[1].String() != "10.99.1.2" {
+		t.Fatal("NewConfig didn't pick up environment variable replacement value for FloatingIPs[1]")
+	}
 
 	// Reset os.Args
 	os.Args = args
@@ -186,6 +196,7 @@ func testJSONConfig(t *testing.T, args []string) {
 	os.Setenv("QUANTUM_LISTEN_PORT", "1")
 	os.Setenv("QUANTUM_CONF_FILE", jsonConfFile)
 	os.Setenv("QUANTUM_PID_FILE", "../quantum.pid")
+	os.Setenv("QUANTUM_FLOATING_IPS", "")
 	os.Setenv("_QUANTUM_REAL_DEVICE_NAME_", "quantum0")
 
 	os.Args = append(args, "-n", "100", "--datastore-prefix", "woot", "--datastore-tls-skip-verify", "-6", "fd00:dead:beef::2", "--network", "", "--network-backend", "", "--network-lease-time", "0")

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -420,10 +420,11 @@ func TestParseMapping(t *testing.T) {
 func TestParseNetworkConfig(t *testing.T) {
 	defaultLeaseTime, _ := time.ParseDuration("48h")
 	DefaultNetworkConfig := &NetworkConfig{
-		Backend:     "udp",
-		Network:     "10.99.0.0/16",
-		StaticRange: "10.99.0.0/23",
-		LeaseTime:   defaultLeaseTime,
+		Backend:       "udp",
+		Network:       "10.99.0.0/16",
+		StaticRange:   "10.99.0.0/23",
+		FloatingRange: "10.99.2.0/23",
+		LeaseTime:     defaultLeaseTime,
 	}
 
 	baseIP, ipnet, _ := net.ParseCIDR(DefaultNetworkConfig.Network)
@@ -432,6 +433,9 @@ func TestParseNetworkConfig(t *testing.T) {
 
 	_, staticNet, _ := net.ParseCIDR(DefaultNetworkConfig.StaticRange)
 	DefaultNetworkConfig.StaticNet = staticNet
+
+	_, floatingNet, _ := net.ParseCIDR(DefaultNetworkConfig.FloatingRange)
+	DefaultNetworkConfig.FloatingNet = floatingNet
 
 	actual, err := ParseNetworkConfig([]byte(DefaultNetworkConfig.String()))
 	if err != nil {
@@ -469,6 +473,26 @@ func TestParseNetworkConfigIncorrectFormat(t *testing.T) {
 	}
 
 	netCfg.StaticRange = "10.20.0.0/23"
+	_, err = ParseNetworkConfig(netCfg.Bytes())
+	if err == nil {
+		t.Fatal("ParseNetworkConfig should have errored")
+	}
+
+	netCfg.StaticRange = "10.99.0.0/23"
+
+	netCfg.FloatingRange = "10.99.0./23"
+	_, err = ParseNetworkConfig(netCfg.Bytes())
+	if err == nil {
+		t.Fatal("ParseNetworkConfig should have errored")
+	}
+
+	netCfg.FloatingRange = "10.20.0.0/23"
+	_, err = ParseNetworkConfig(netCfg.Bytes())
+	if err == nil {
+		t.Fatal("ParseNetworkConfig should have errored")
+	}
+
+	netCfg.FloatingRange = "10.99.0.0/23"
 	_, err = ParseNetworkConfig(netCfg.Bytes())
 	if err == nil {
 		t.Fatal("ParseNetworkConfig should have errored")

--- a/common/ipHandler.go
+++ b/common/ipHandler.go
@@ -26,10 +26,20 @@ func ipExists(ip net.IP, mappings map[uint32]*Mapping) bool {
 	return false
 }
 
+func nonFloatingIPExists(ip net.IP, mappings map[uint32]*Mapping) bool {
+	for _, mapping := range mappings {
+		if ArrayEquals(ip.To4(), mapping.PrivateIP.To4()) && !mapping.Floating {
+			return true
+		}
+	}
+	return false
+}
+
 func getFreeIP(cfg *Config, mappings map[uint32]*Mapping) (net.IP, error) {
 	for ip := cfg.NetworkConfig.BaseIP.Mask(cfg.NetworkConfig.IPNet.Mask); cfg.NetworkConfig.IPNet.Contains(ip); IncrementIP(ip) {
 		if ip[3] == 0 || ip[3] == 255 ||
 			(cfg.NetworkConfig.StaticNet != nil && cfg.NetworkConfig.StaticNet.Contains(ip)) ||
+			(cfg.NetworkConfig.FloatingNet != nil && cfg.NetworkConfig.FloatingNet.Contains(ip)) ||
 			ipExists(ip, mappings) {
 			continue
 		}
@@ -52,7 +62,24 @@ func GenerateLocalMapping(cfg *Config, mappings map[uint32]*Mapping) (*Mapping, 
 		}
 	} else if _, exists := getLocalMappingIfExists(cfg.MachineID, mappings); !exists && ipExists(cfg.PrivateIP, mappings) {
 		return nil, errors.New("statically assigned private ip address belongs to another server")
+	} else if !cfg.NetworkConfig.IPNet.Contains(cfg.PrivateIP) {
+		return nil, errors.New("statically assigned private ip address does not lie within the overall network range")
 	}
 
 	return NewMapping(cfg), nil
+}
+
+// GenerateFloatingMapping will take in the user defined configuration plus the currently defined mappins, in order to determine the floating mapping.
+func GenerateFloatingMapping(cfg *Config, i int, mappings map[uint32]*Mapping) (*Mapping, error) {
+	if nonFloatingIPExists(cfg.FloatingIPs[i], mappings) {
+		return nil, errors.New("the floating ip '" + cfg.FloatingIPs[i].String() + "' is already assigned to a different node as a static or dhcp ip address")
+	} else if cfg.NetworkConfig.StaticNet != nil && cfg.NetworkConfig.StaticNet.Contains(cfg.FloatingIPs[i]) {
+		return nil, errors.New("the floating ip '" + cfg.FloatingIPs[i].String() + "' lies within the reserved static ip range")
+	} else if cfg.NetworkConfig.FloatingNet != nil && !cfg.NetworkConfig.FloatingNet.Contains(cfg.FloatingIPs[i]) {
+		return nil, errors.New("the floating ip '" + cfg.FloatingIPs[i].String() + "' does not lie within the reserved floating ip range")
+	} else if !cfg.NetworkConfig.IPNet.Contains(cfg.FloatingIPs[i]) {
+		return nil, errors.New("the floating ip '" + cfg.FloatingIPs[i].String() + "' does not lie within the overall network range")
+	}
+
+	return NewFloatingMapping(cfg, i), nil
 }

--- a/common/mapping.go
+++ b/common/mapping.go
@@ -23,6 +23,9 @@ type Mapping struct {
 	// The port where quantum is listening for remote packets.
 	Port int `json:"port"`
 
+	// Whether or not this mapping represents a floating ip address.
+	Floating bool `jsone:"floating"`
+
 	// The public ipv4 address of the node represented by this mapping, which may or may not exist.
 	IPv4 net.IP `json:"ipv4,omitempty"`
 
@@ -107,5 +110,21 @@ func NewMapping(cfg *Config) *Mapping {
 		SupportedPlugins: cfg.Plugins,
 		PublicKey:        cfg.PublicKey,
 		PublicSalt:       cfg.PublicSalt,
+		Floating:         false,
+	}
+}
+
+// NewFloatingMapping generates a new basic Mapping with no cryptographic metadata.
+func NewFloatingMapping(cfg *Config, i int) *Mapping {
+	return &Mapping{
+		MachineID:        cfg.MachineID,
+		IPv4:             cfg.PublicIPv4,
+		IPv6:             cfg.PublicIPv6,
+		Port:             cfg.ListenPort,
+		PrivateIP:        cfg.FloatingIPs[i],
+		SupportedPlugins: cfg.Plugins,
+		PublicKey:        cfg.PublicKey,
+		PublicSalt:       cfg.PublicSalt,
+		Floating:         true,
 	}
 }

--- a/common/mapping.go
+++ b/common/mapping.go
@@ -24,7 +24,7 @@ type Mapping struct {
 	Port int `json:"port"`
 
 	// Whether or not this mapping represents a floating ip address.
-	Floating bool `jsone:"floating"`
+	Floating bool `json:"floating"`
 
 	// The public ipv4 address of the node represented by this mapping, which may or may not exist.
 	IPv4 net.IP `json:"ipv4,omitempty"`

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -39,12 +39,12 @@ type Datastore interface {
 }
 
 // New generates a datastore object based on the passed in Type and user configuration.
-func New(datastoreType Type, log *common.Logger, cfg *common.Config) (Datastore, error) {
+func New(datastoreType Type, cfg *common.Config) (Datastore, error) {
 	switch datastoreType {
 	case ETCDDatastore:
-		return newEtcd(log, cfg)
+		return newEtcd(cfg)
 	case MOCKDatastore:
-		return newMock(log, cfg)
+		return newMock(cfg)
 	default:
 		return nil, errors.New("specified backend doesn't exist")
 	}

--- a/datastore/etcd.go
+++ b/datastore/etcd.go
@@ -120,11 +120,13 @@ func (etcd *Etcd) lockFloatingIP(key, value string) {
 }
 
 func (etcd *Etcd) handleFloatingMappings() error {
-	mappings := make([]*common.Mapping, len(etcd.cfg.FloatingIPs))
+	for i := 0; i < len(etcd.cfg.FloatingIPs); i++ {
+		mapping, err := common.GenerateFloatingMapping(etcd.cfg, i, etcd.mappings)
+		if err != nil {
+			return err
+		}
 
-	for i := 0; i < len(mappings); i++ {
-		mappings[i] = common.NewFloatingMapping(etcd.cfg, i)
-		go etcd.lockFloatingIP(etcd.key("nodes", mappings[i].PrivateIP.String()), mappings[i].String())
+		go etcd.lockFloatingIP(etcd.key("nodes", mapping.PrivateIP.String()), mapping.String())
 	}
 
 	return nil

--- a/datastore/etcd.go
+++ b/datastore/etcd.go
@@ -334,7 +334,7 @@ func (etcd *Etcd) Start() {
 				}
 			}
 		}
-		close(etcd.stopSyncing)
+
 		ticker.Stop()
 	}()
 }

--- a/datastore/mock.go
+++ b/datastore/mock.go
@@ -30,6 +30,6 @@ func (mock *Mock) Start() {
 func (mock *Mock) Stop() {
 }
 
-func newMock(log *common.Logger, cfg *common.Config) (Datastore, error) {
+func newMock(cfg *common.Config) (Datastore, error) {
 	return &Mock{}, nil
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,9 +22,8 @@ services:
       - $GOPATH/src/github.com/Supernomad/quantum/dist/ssl/keys/:/etc/quantum/ssl/keys/:ro
       - quantum0:/var/lib/quantum/
     networks:
-      quantum_dev_net_v4:
+      quantum_dev_net:
         ipv4_address: 172.18.0.2
-      quantum_dev_net_v6:
         ipv6_address: fd00:dead:beef::2
     entrypoint:
       - "/bin/start_quantum.sh"
@@ -46,6 +45,8 @@ services:
       - "/etc/quantum/ssl/certs/ec-ca.crt"
       - "--plugins"
       - "compression,encryption"
+      - "--floating-ips"
+      - "10.99.1.1"
   quantum1:
     cpuset: "0,1,2"
     container_name: quantum1
@@ -75,10 +76,10 @@ services:
       QUANTUM_DTLS_CERT: "/etc/quantum/ssl/certs/ec-server.crt"
       QUANTUM_DTLS_KEY: "/etc/quantum/ssl/keys/ec-server.key"
       QUANTUM_PLUGINS: "compression"
+      QUANTUM_FLOATING_IPS: "10.99.1.1"
     networks:
-      quantum_dev_net_v4:
+      quantum_dev_net:
         ipv4_address: 172.18.0.3
-      quantum_dev_net_v6:
         ipv6_address: fd00:dead:beef::3
     entrypoint: ["/bin/start_quantum.sh"]
   quantum2:
@@ -102,9 +103,8 @@ services:
     environment:
       QUANTUM_CONF_FILE: "/etc/quantum/quantum.yml"
     networks:
-      quantum_dev_net_v4:
+      quantum_dev_net:
         ipv4_address: 172.18.0.5
-      quantum_dev_net_v6:
         ipv6_address: fd00:dead:beef::5
     entrypoint: ["/bin/start_quantum.sh"]
   etcd:
@@ -120,9 +120,8 @@ services:
     ports:
       - 2379:2379
     networks:
-      quantum_dev_net_v4:
+      quantum_dev_net:
         ipv4_address: 172.18.0.4
-      quantum_dev_net_v6:
         ipv6_address: fd00:dead:beef::4
     environment:
       ETCD_LISTEN_CLIENT_URLS: "https://[fd00:dead:beef::4]:2379, https://172.18.0.4:2379"
@@ -134,12 +133,9 @@ services:
       ETCD_NAME: "datastore"
     entrypoint: ["/usr/local/bin/etcd", "--client-cert-auth=true"]
 networks:
-  quantum_dev_net_v4:
+  quantum_dev_net:
     external:
-      name: quantum_dev_net_v4
-  quantum_dev_net_v6:
-    external:
-      name: quantum_dev_net_v6
+      name: quantum_dev_net
 volumes:
   etcd:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 # Copyright (c) 2016-2017 Christian Saide <Supernomad>
 # Licensed under the MPL-2.0, for details see https://github.com/Supernomad/quantum/blob/master/LICENSE
 
-version: "2"
+version: "2.1"
 services:
   quantum0:
     cpuset: "2,3"
@@ -22,7 +22,7 @@ services:
       - $GOPATH/src/github.com/Supernomad/quantum/dist/ssl/keys/:/etc/quantum/ssl/keys/:ro
       - quantum0:/var/lib/quantum/
     networks:
-      quantum_dev_net:
+      local:
         ipv4_address: 172.18.0.2
         ipv6_address: fd00:dead:beef::2
     entrypoint:
@@ -78,7 +78,7 @@ services:
       QUANTUM_PLUGINS: "compression"
       QUANTUM_FLOATING_IPS: "10.99.2.1"
     networks:
-      quantum_dev_net:
+      local:
         ipv4_address: 172.18.0.3
         ipv6_address: fd00:dead:beef::3
     entrypoint: ["/bin/start_quantum.sh"]
@@ -103,7 +103,7 @@ services:
     environment:
       QUANTUM_CONF_FILE: "/etc/quantum/quantum.yml"
     networks:
-      quantum_dev_net:
+      local:
         ipv4_address: 172.18.0.5
         ipv6_address: fd00:dead:beef::5
     entrypoint: ["/bin/start_quantum.sh"]
@@ -120,7 +120,7 @@ services:
     ports:
       - 2379:2379
     networks:
-      quantum_dev_net:
+      local:
         ipv4_address: 172.18.0.4
         ipv6_address: fd00:dead:beef::4
     environment:
@@ -133,9 +133,16 @@ services:
       ETCD_NAME: "datastore"
     entrypoint: ["/usr/local/bin/etcd", "--client-cert-auth=true"]
 networks:
-  quantum_dev_net:
-    external:
-      name: quantum_dev_net
+  local:
+    driver: bridge
+    enable_ipv6: true
+    ipam:
+      driver: default
+      config:
+        - subnet: '172.18.0.0/24'
+          gateway: '172.18.0.1'
+        - subnet: 'fd00:dead:beef::/64'
+          gateway: 'fd00:dead:beef::1'
 volumes:
   etcd:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - "--plugins"
       - "compression,encryption"
       - "--floating-ips"
-      - "10.99.1.1"
+      - "10.99.2.1"
   quantum1:
     cpuset: "0,1,2"
     container_name: quantum1
@@ -76,7 +76,7 @@ services:
       QUANTUM_DTLS_CERT: "/etc/quantum/ssl/certs/ec-server.crt"
       QUANTUM_DTLS_KEY: "/etc/quantum/ssl/keys/ec-server.key"
       QUANTUM_PLUGINS: "compression"
-      QUANTUM_FLOATING_IPS: "10.99.1.1"
+      QUANTUM_FLOATING_IPS: "10.99.2.1"
     networks:
       quantum_dev_net:
         ipv4_address: 172.18.0.3

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func main() {
 	cfg, err := common.NewConfig(log)
 	handleError(log, err)
 
-	store, err := datastore.New(datastore.ETCDDatastore, log, cfg)
+	store, err := datastore.New(datastore.ETCDDatastore, cfg)
 	handleError(log, err)
 
 	err = store.Init()


### PR DESCRIPTION
This PR introduces the idea of floating IP's into quantum, first described in #58. there is still some work that needs to be done, but the basic framework is implemented and the functionality is working as expected. It also includes a pretty large refactoring of the etcd code in general to make it more robust and hopefully maintainable moving forward.

Functionality is based on the following setup:
- `quantum` can be given an arbitrary list of floating ips at run time. Given that those floating ip's are not already assigned as static/dhcp ip's, and exist within the `quantum` network.
- `quantum` will attempt to acquire the floating ips ad infinitum.
- `quantum` will refresh the acquired floating ips once acquired based on the provided floating ip ttl which is defaulted to 10s, each instance will refresh twice per ttl timespan.
- `quantum` there is no limit to the number of nodes that can participate in a single floating ip "group", meaning any number of instances can attempt to acquire a given floating ip.
- `quantum` will maintain the same guarantee of continuing to use the last set of observed mappings given a partition occurs and it is not possible to communicate with the etcd cluster. Meaning if connection with etcd is lost `quantum` will continue to talk to the last node it observed controlling any given floating ip. 

Remaining work that is required:
- [x] Ensure proper error handling of floating ip's that collide with static ip's.
- [x] Ensure proper error handling of floating ip's that collide with dhcp assigned ip's.
- [x] Ensure proper error handling of floating ip's that are assigned which are outside the proper network range.
- [x] Ensure unit tests are fully updated.
- [x] Ensure that rolling restart is properly handled.